### PR TITLE
Check for canary file in the `iojs` header folder aswell.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,20 +2,19 @@ import path from 'path';
 import _ from 'lodash';
 import childProcess from 'child_process';
 import spawn from './spawn';
-import promisify from './promisify';
 export { preGypFixRun } from './node-pre-gyp-fix';
 
-const fs = promisify(require('fs'));
+const fs = require('fs');
 
 const getHeadersRootDirForVersion = (version) => {
   return path.resolve(__dirname, 'headers');
 };
 
 const checkForInstalledHeaders = async function(nodeVersion, headersDir) {
-  const canary = path.join(headersDir, '.node-gyp', nodeVersion, 'common.gypi');
-  let stat = await fs.stat(canary);
+  const canaryNode = path.join(headersDir, '.node-gyp', nodeVersion, 'common.gypi');
+  const canaryIoJS = path.join(headersDir, '.node-gyp', `iojs-${nodeVersion}`, 'common.gypi');
 
-  if (!stat) throw new Error("Canary file 'common.gypi' doesn't exist");
+  if (!(fs.existsSync(canaryNode) || fs.existsSync(canaryIoJS))) throw new Error("Canary file 'common.gypi' doesn't exist");
   return true;
 };
 


### PR DESCRIPTION
This PR fixes #66 

Basically `node-gyp` treats versions `1.x.y` to `3.x.y` as `iojs` so the major bump to `1.x.y` on electron caused node-gyp to download to a `iojs-{version}` folder instead of `{version}` folder.

This PR simply checks if either exists

/cc @parro-it @jostrander