### PR TITLE
Use ELECTRON_RUN_AS_NODE env var

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,7 @@ const spawnWithHeadersDir = async (cmd, args, headersDir, cwd) => {
 
 export async function getElectronModuleVersion(pathToElectronExecutable) {
   let args = [ '-e', 'console.log(process.versions.modules)' ]
-  let env = { ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1', ELECTRON_NO_ATTACH_CONSOLE: '1' };
+  let env = { ELECTRON_RUN_AS_NODE: '1', ELECTRON_NO_ATTACH_CONSOLE: '1' };
 
   let result = await spawn({cmd: pathToElectronExecutable, args, opts: {env}});
   let versionAsString = (result.stdout + result.stderr).replace(/\n/g, '');

--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,11 @@ const spawnWithHeadersDir = async (cmd, args, headersDir, cwd) => {
 
 export async function getElectronModuleVersion(pathToElectronExecutable) {
   let args = [ '-e', 'console.log(process.versions.modules)' ]
-  let env = { ELECTRON_RUN_AS_NODE: '1', ELECTRON_NO_ATTACH_CONSOLE: '1' };
+  let env = {
+    ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1',
+    ELECTRON_RUN_AS_NODE: '1',
+    ELECTRON_NO_ATTACH_CONSOLE: '1'
+  };
 
   let result = await spawn({cmd: pathToElectronExecutable, args, opts: {env}});
   let versionAsString = (result.stdout + result.stderr).replace(/\n/g, '');


### PR DESCRIPTION
`ATOM_SHELL_INTERNAL_RUN_AS_NODE` was not part of the `1.0` and removed in `1.2`.

Refs electron/electron#5682
Closes https://github.com/electron/electron-rebuild/issues/70