### PR TITLE
Added a notice about windows errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ Or if you're on Windows:
 ```sh
 .\node_modules\.bin\electron-rebuild.cmd
 ```
-
+If you have a good node-gyp config but you see an error about a missing element on Windows like "Could not load the Visual C++ component "VCBuild.exe" , try to launch electron-rebuild in a npm script
+```json
+'scripts': {
+  'rebuild' : 'electron-rebuild -f -w yourmodule'
+}
+```
+and then
+```sh
+npm run rebuild
+```
 ### How can I integrate this into Grunt / Gulp / Whatever?
 
 electron-rebuild is also a library that you can just require into your app or


### PR DESCRIPTION
I've spent a long time figuring out why i couldn't rebuild my modules. On windows, even if your configuration is correct , there is environment difficulties and running it throught an npm script do the job. 
I found some informations by reading the issues but maybe it could be nice to have this in the main documentation