### PR TITLE
Add new methods to find the electron-prebuilt directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"
+
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "babel --stage 1 --optional runtime -d lib/ src/ && babel --stage 1 --optional runtime -d test-dist/ test/",
     "prepublish": "npm run compile",
-    "test": "npm run compile && mocha test-dist/*"
+    "test": "npm run compile && mocha test-dist/* --timeout 120000"
   },
   "bin": {
     "electron-rebuild": "lib/cli.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import {installNodeHeaders, rebuildNativeModules, shouldRebuildNativeModules} from './main.js';
-import { preGypFixRun } from './node-pre-gyp-fix.js'
+import {preGypFixRun} from './node-pre-gyp-fix.js'
+import {locateElectronPrebuilt} from './electron-locater';
 import path from 'path';
 import fs from 'fs';
 
@@ -39,10 +40,7 @@ if (argv.h) {
 }
 
 if (!argv.e) {
-  argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt');
-  if (!fs.existsSync(argv.e)) {
-    argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt-compile');
-  }
+  argv.e = locateElectronPrebuilt();
 } else {
   argv.e = path.resolve(process.cwd(), argv.e);
 }

--- a/src/electron-locater.js
+++ b/src/electron-locater.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+
+export const locateElectronPrebuilt = () => {
+  let electronPath = path.join(__dirname, '..', '..', 'electron');
+  if (!fs.existsSync(electronPath)) {
+    electronPath = path.join(__dirname, '..', '..', 'electron-prebuilt');
+  }
+  if (!fs.existsSync(electronPath)) {
+    electronPath = path.join(__dirname, '..', '..', 'electron-prebuilt-compile');
+  }
+  if (!fs.existsSync(electronPath)) {
+    try {
+      electronPath = path.join(require.resolve('electron'), '..');
+    } catch (e) {
+      // Module not found, do nothing
+    }
+  }
+  if (!fs.existsSync(electronPath)) {
+    try {
+      electronPath = path.join(require.resolve('electron-prebuilt'), '..');
+    } catch (e) {
+      // Module not found, do nothing
+    }
+  }
+  if (!fs.existsSync(electronPath)) {
+    electronPath = null;
+  }
+  return electronPath;
+}

--- a/test/electron-locater.js
+++ b/test/electron-locater.js
@@ -1,0 +1,60 @@
+import _ from './support';
+import fs from 'fs';
+import npm from 'npm';
+import path from 'path';
+import promisify from '../lib/promisify.js';
+import {spawn} from 'child_process';
+
+import {locateElectronPrebuilt} from '../lib/electron-locater';
+
+const packageCommand = (command, packageName) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(path.resolve(__dirname, '..', 'node_modules', '.bin', `npm${process.platform === 'win32' ? '.cmd' : ''}`), [command, packageName], {
+      cwd: path.resolve(__dirname, '..')
+    });
+
+    child.stdout.on('data', () => {});
+    child.stderr.on('data', () => {});
+
+    child.on('close', (code) => {
+      if (code === 0) return resolve();
+      reject(code);
+    });
+  })
+
+const install = packageCommand.bind(this, 'install');
+const uninstall = packageCommand.bind(this, 'uninstall');
+
+const testElectronCanBeFound = () => {
+  it('should return a valid path', () => {
+    const electronPath = locateElectronPrebuilt();
+    electronPath.should.be.a('string');
+    fs.existsSync(electronPath).should.be.equal(true);
+  });
+};
+
+describe('locateElectronPrebuilt', () => {
+  before(() => uninstall('electron-prebuilt'));
+
+  it('should return null when electron is not installed', () => {
+    expect(locateElectronPrebuilt()).to.be.equal(null);
+  });
+
+  describe('with electron-prebuilt installed', () => {
+    before(() => install('electron-prebuilt'));
+
+    testElectronCanBeFound();
+
+    after(() => uninstall('electron-prebuilt'));
+  });
+
+  describe('with electron installed', () => {
+    before(() => install('electron'));
+
+    testElectronCanBeFound();
+
+    after(() => uninstall('electron'));
+  });
+
+  after(() => install('electron-prebuilt'));
+});

--- a/test/electron-locater.js
+++ b/test/electron-locater.js
@@ -1,8 +1,6 @@
 import _ from './support';
 import fs from 'fs';
-import npm from 'npm';
 import path from 'path';
-import promisify from '../lib/promisify.js';
 import {spawn} from 'child_process';
 
 import {locateElectronPrebuilt} from '../lib/electron-locater';


### PR DESCRIPTION
Fixes #91

This checks the `electron` node_modules directory and attempts to resolve the `electron` and `electron-prebuilt` packages as fallbacks.