### PR TITLE
add contributing doc

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,40 @@
+# Contributing to electron-rebuild
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable
+behavior to electron@github.com.
+
+The following is a set of guidelines for contributing to electron-rebuild.
+These are just guidelines, not rules, use your best judgment and feel free to
+propose changes to this document in a pull request.
+
+## Submitting Issues
+
+* You can create an issue [here](https://github.com/electron/electron-rebuild/issues/new),
+but before doing that please read the notes below and include as many details as
+possible with your report. If you can, please include:
+  * The version of electron and electron-rebuild you are using
+  * The operating system you are using
+  * If applicable, what you were doing when the issue arose and what you
+  expected to happen
+* Other things that will help resolve your issue:
+  * Screenshots and animated GIFs
+  * Error output that appears in your terminal, dev tools or as an alert
+  * Perform a [cursory search](https://github.com/electron/electron-rebuild/issues?utf8=✓&q=is%3Aissue+)
+  to see if a similar issue has already been submitted
+
+## Submitting Pull Requests
+
+* Include screenshots and animated GIFs in your pull request whenever possible.
+* Write documentation in [Markdown](https://daringfireball.net/projects/markdown).
+* Use short, present tense commit messages. See [Commit Message Styleguide](#git-commit-messages).
+
+## Git Commit Messages
+
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Reference issues and pull requests liberally
+* When only changing documentation, include `[ci skip]` in the commit description


### PR DESCRIPTION
I just copied the doc from `electron/electron`, updated the project name, and took out the electron-specific bits about C++ and Python code style, etc.

cc @jlord @kevinsawicki 