### PR TITLE
update version in package.json to match npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-rebuild",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Electron supporting package to rebuild native node modules against the currently installed electron",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
Following up on https://github.com/electron/electron-rebuild/issues/91#issuecomment-241937379

This updates `version` in package.json to match what's on npm.

I guess this was me messing up somehow but it looks like [this has happened before](https://github.com/electron/electron-rebuild/issues/79)?

