### PR TITLE
Export more methods and make an index.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron-rebuild",
   "version": "1.3.0",
   "description": "Electron supporting package to rebuild native node modules against the currently installed electron",
-  "main": "lib/main.js",
+  "main": "lib/index.js",
   "scripts": {
     "compile": "babel --stage 1 --optional runtime -d lib/ src/ && babel --stage 1 --optional runtime -d test-dist/ test/",
     "prepublish": "npm run compile",

--- a/src/electron-locater.js
+++ b/src/electron-locater.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 const possibleModuleNames = ['electron', 'electron-prebuilt', 'electron-prebuilt-compile'];
 
-export const locateElectronPrebuilt = () => {
+export function locateElectronPrebuilt() {
   let electronPath;
 
   // Attempt to locate modules by path

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+import { locateElectronPrebuilt } from './electron-locater';
+
+module.exports = Object.assign({
+    locateElectronPrebuilt
+}, require('./main'));


### PR DESCRIPTION
This PR exports the `locateElectronPrebuilt` method as well as makes it a bit easier to decide what gets exported and what doesn't -cc @zeke 