### PR TITLE
Handle the case where the module specifies an output path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
 - '6'
-- '4'
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/electron/electron-rebuild/issues"
   },
   "homepage": "https://github.com/electron/electron-rebuild",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "dependencies": {
     "babel-register": "^6.16.3",
     "babel-runtime": "6.18.0",


### PR DESCRIPTION
* Replaces the standard node-gyp bindings template strings

Fixes #137