### PR TITLE
add node-pre-gyp support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "fs-promise": "^2.0.2",
     "node-abi": "^2.0.0",
     "node-gyp": "^3.6.0",
+    "node-pre-gyp": "^0.6.34",
     "ora": "^1.2.0",
     "rimraf": "^2.6.1",
     "spawn-rx": "^2.0.10",

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -175,7 +175,9 @@ class Rebuilder {
     });
 
     d('built:', moduleName);
-    await fs.mkdirs(path.dirname(metaPath));
+    if (!(await fs.exists(metaPath))) {
+      await fs.mkdirs(path.dirname(metaPath));
+    }
     await fs.writeFile(metaPath, metaData);
 
     d('searching for .node file', moduleBinaryPath);
@@ -189,7 +191,9 @@ class Rebuilder {
     if (await fs.exists(nodePath)) {
       d('found .node file', nodePath);
       d('copying to prebuilt place:', abiPath);
-      await fs.mkdirs(abiPath);
+      if (!(await fs.exists(abiPath))) {
+        await fs.mkdirs(abiPath);
+      }
       await fs.copy(nodePath, path.resolve(abiPath, `${moduleName}.node`));
     }
 

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -6,21 +6,30 @@ import * as nodeAbi from 'node-abi';
 import * as os from 'os';
 import * as path from 'path';
 import { readPackageJson } from './read-package-json';
+import {isNullOrUndefined} from 'util';
 
 const d = debug('electron-rebuild');
 
 const defaultMode = process.platform === 'win32' ? 'sequential' : 'parallel';
 
-const locateNodeGyp = async () => {
+const locateGypModule = async(cli: string) => {
   let testPath = __dirname;
   for (let upDir = 0; upDir <= 20; upDir++) {
-    const nodeGypTestPath = path.resolve(testPath, `node_modules/.bin/node-gyp${process.platform === 'win32' ? '.cmd' : ''}`);
+    const nodeGypTestPath = path.resolve(testPath, `node_modules/.bin/${cli}${process.platform === 'win32' ? '.cmd' : ''}`);
     if (await fs.exists(nodeGypTestPath)) {
       return nodeGypTestPath;
     }
     testPath = path.resolve(testPath, '..');
   }
   return null;
+};
+
+const locateNodeGyp = async () => {
+  return await locateGypModule('node-gyp');
+};
+
+const locateNodePreGyp = async () => {
+  return await locateGypModule('node-pre-gyp');
 };
 
 class Rebuilder {
@@ -92,8 +101,9 @@ class Rebuilder {
     }
 
     const nodeGypPath = await locateNodeGyp();
-    if (!nodeGypPath) {
-      throw new Error('Could not locate node-gyp');
+    const nodePreGypPath = await locateNodePreGyp();
+    if (!nodeGypPath || !nodePreGypPath) {
+      throw new Error('Could not locate node-gyp or node-pre-gyp');
     }
 
     const metaPath = path.resolve(modulePath, 'build', 'Release', '.forge-meta');
@@ -115,28 +125,33 @@ class Rebuilder {
       return;
     }
     d('rebuilding:', path.basename(modulePath));
+    const modulePackageJson = await readPackageJson(modulePath);
+    const moduleName = path.basename(modulePath);
+    let moduleBinaryPath = path.resolve(modulePath, 'build/Release');
+    const preGypReady = !isNullOrUndefined(modulePackageJson.binary);
+
     const rebuildArgs = [
-      'rebuild',
+      preGypReady ? 'reinstall' : 'rebuild',
       `--target=${this.electronVersion}`,
       `--arch=${this.arch}`,
       `--dist-url=${this.headerURL}`,
-      '--build-from-source',
+      preGypReady ? '--fallback-to-build' : '--build-from-source',
     ];
-
-    const modulePackageJson = await readPackageJson(modulePath);
 
     Object.keys(modulePackageJson.binary || {}).forEach((binaryKey) => {
       let value = modulePackageJson.binary[binaryKey];
-
-      if (binaryKey === 'module_path') {
-        value = path.resolve(modulePath, value);
-      }
 
       value = value.replace('{configuration}', 'Release')
         .replace('{node_abi}', `electron-v${this.electronVersion.split('.').slice(0, 2).join('.')}`)
         .replace('{platform}', process.platform)
         .replace('{arch}', this.arch)
-        .replace('{version}', modulePackageJson.version);
+        .replace('{version}', modulePackageJson.version)
+        .replace('{name}', modulePackageJson.name);
+
+      if (binaryKey === 'module_path') {
+        value = path.resolve(modulePath, value);
+        moduleBinaryPath = value;
+      }
 
       Object.keys(modulePackageJson.binary).forEach((binaryReplaceKey) => {
         value = value.replace(`{${binaryReplaceKey}}`, modulePackageJson.binary[binaryReplaceKey]);
@@ -145,8 +160,8 @@ class Rebuilder {
       rebuildArgs.push(`--${binaryKey}=${value}`);
     });
 
-    d('rebuilding', path.basename(modulePath), 'with args', rebuildArgs);
-    await spawnPromise(nodeGypPath, rebuildArgs, {
+    d('rebuilding', moduleName, 'with args', rebuildArgs);
+    await spawnPromise(preGypReady ? nodePreGypPath : nodeGypPath, rebuildArgs, {
       cwd: modulePath,
       env: Object.assign({}, process.env, {
         HOME: path.resolve(os.homedir(), '.electron-gyp'),
@@ -155,20 +170,18 @@ class Rebuilder {
         npm_config_runtime: 'electron',
         npm_config_arch: this.arch,
         npm_config_target_arch: this.arch,
-        npm_config_build_from_source: true,
+        npm_config_build_from_source: !preGypReady,
       }),
     });
 
-    d('built:', path.basename(modulePath));
+    d('built:', moduleName);
     await fs.mkdirs(path.dirname(metaPath));
     await fs.writeFile(metaPath, metaData);
 
-    const moduleName = path.basename(modulePath);
-
-    d('searching for .node file', path.resolve(modulePath, 'build/Release'));
-    d('testing files', (await fs.readdir(path.resolve(modulePath, 'build/Release'))));
-    const nodePath = path.resolve(modulePath, 'build/Release',
-      (await fs.readdir(path.resolve(modulePath, 'build/Release')))
+    d('searching for .node file', moduleBinaryPath);
+    d('testing files', (await fs.readdir(moduleBinaryPath)));
+    const nodePath = path.resolve(moduleBinaryPath,
+      (await fs.readdir(moduleBinaryPath))
         .find((file) => file !== '.node' && file.endsWith('.node'))
       );
 


### PR DESCRIPTION
This PR modifies electron-rebuild to use node-pre-gyp if the binary section is present. It uses the --fallback-to-build option to build the dependency if no prebuild binary is available. 