### PR TITLE
fix: do not ignore input modules provided via -w

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: node_js
-node_js:
-- '6'
-
 sudo: false
-
-os:
-- linux
-- osx
-
 env:
   global:
     - CC=clang CXX=clang++ npm_config_clang=1
 
-branches:
-  only:
-  - master
-  - /^v\d+\.\d+\.\d+/
+matrix:
+  fast_finish: true
+  include:
+    - node_js: "6"
+      os: linux
+      env: SCRIPT=lint
+    - node_js: "6"
+      os: linux
+      env: SCRIPT=test
+    - node_js: "6"
+      os: osx
+      env: SCRIPT=test
 
-script: npm run test
+script:
+  - if [[ "$SCRIPT" ]]; then npm run-script $SCRIPT; fi

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
                                on macOS and Linux
   -s, --sequential             Rebuild modules sequentially, this is enabled by
                                default on Windows
+  -o, --only                   Only build specified module, or comma separated
+                               list of modules. All others are ignored.
 
 Copyright 2016
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,15 @@ process.on('unhandledRejection', handler);
     }
   }
 
-  const rebuilder = rebuild(rootDirectory, electronPrebuiltVersion, argv.a || process.arch, argv.w ? argv.w.split(',') : [], argv.f, argv.d, argv.t ? argv.t.split(',') : ['prod', 'dev'], argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined), argv.o ? argv.o.split(',') : []);
+  const rebuilder = rebuild(
+    rootDirectory,
+    electronPrebuiltVersion,
+    argv.a || process.arch,
+    argv.w ? argv.w.split(',') : [],
+    argv.o ? argv.o.split(',') : [],
+    argv.f, argv.d, argv.t ? argv.t.split(',') : ['prod', 'dev'],
+    argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined)
+  );
 
   const lifecycle = rebuilder.lifecycle;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,8 @@ const yargs = require('yargs')
   .alias('m', 'module-dir')
   .describe('w', 'A specific module to build, or comma separated list of modules')
   .alias('w', 'which-module')
+  .describe('o', 'Only build specified module, or comma separated list of modules. All others are ignored.')
+  .alias('o', 'only')
   .describe('e', 'The path to electron-prebuilt')
   .alias('e', 'electron-prebuilt-dir')
   .describe('d', 'Custom header tarball URL')
@@ -53,7 +55,7 @@ process.on('unhandledRejection', handler);
 
 (async () => {
   const electronPrebuiltPath = argv.e ? path.resolve(process.cwd(), argv.e) : locateElectronPrebuilt();
-  let electronPrebuiltVersion = argv.v; 
+  let electronPrebuiltVersion = argv.v;
 
   if (!electronPrebuiltVersion) {
     try {
@@ -83,7 +85,7 @@ process.on('unhandledRejection', handler);
   } else {
     rootDirectory = path.resolve(process.cwd(), rootDirectory);
   }
-  
+
   let modulesDone = 0;
   let moduleTotal = 0;
   const rebuildSpinner = ora('Searching dependency tree').start();
@@ -98,7 +100,7 @@ process.on('unhandledRejection', handler);
     }
   }
 
-  const rebuilder = rebuild(rootDirectory, electronPrebuiltVersion, argv.a || process.arch, argv.w ? argv.w.split(',') : [], argv.f, argv.d, argv.t ? argv.t.split(',') : ['prod', 'dev'], argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined));
+  const rebuilder = rebuild(rootDirectory, electronPrebuiltVersion, argv.a || process.arch, argv.w ? argv.w.split(',') : [], argv.f, argv.d, argv.t ? argv.t.split(',') : ['prod', 'dev'], argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined), argv.o ? argv.o.split(',') : []);
 
   const lifecycle = rebuilder.lifecycle;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,11 +4,12 @@ import 'colors';
 import * as fs from 'fs-promise';
 import * as path from 'path';
 import * as ora from 'ora';
+import * as yargs from 'yargs';
 
 import { rebuild } from './rebuild';
 import { locateElectronPrebuilt } from './electron-locater';
 
-const yargs = require('yargs')
+const args = yargs
   .usage('Usage: electron-rebuild --version [version] --module-dir [path]')
   .help('h')
   .alias('h', 'help')
@@ -36,7 +37,7 @@ const yargs = require('yargs')
   .alias('s', 'sequential')
   .epilog('Copyright 2016');
 
-const argv = yargs.argv;
+const argv = args.argv;
 
 if (argv.h) {
   yargs.showHelp();
@@ -59,7 +60,10 @@ process.on('unhandledRejection', handler);
 
   if (!electronPrebuiltVersion) {
     try {
-      if (!electronPrebuiltPath) throw new Error("electron-prebuilt not found");
+      if (!electronPrebuiltPath) {
+        throw new Error('electron-prebuilt not found');
+      }
+
       const pkgJson = require(path.join(electronPrebuiltPath, 'package.json'));
 
       electronPrebuiltVersion = pkgJson.version;
@@ -92,13 +96,16 @@ process.on('unhandledRejection', handler);
   let lastModuleName: string;
 
   const redraw = (moduleName?: string) => {
-    if (moduleName) lastModuleName = moduleName;
+    if (moduleName) {
+      lastModuleName = moduleName;
+    }
+
     if (argv.p) {
       rebuildSpinner.text = `Building modules: ${modulesDone}/${moduleTotal}`;
     } else {
       rebuildSpinner.text = `Building module: ${lastModuleName}, Completed: ${modulesDone}`;
     }
-  }
+  };
 
   const rebuilder = rebuild(
     rootDirectory,

--- a/src/electron-locater.ts
+++ b/src/electron-locater.ts
@@ -13,7 +13,9 @@ export function locateElectronPrebuilt() {
   });
 
   // Return a path if we found one
-  if (foundModule) return electronPath;
+  if (foundModule) {
+    return electronPath;
+  }
 
   // Attempt to locate modules by require
   foundModule = possibleModuleNames.some((moduleName) => {
@@ -27,6 +29,9 @@ export function locateElectronPrebuilt() {
   });
 
   // Return a path if we found one
-  if (foundModule) return electronPath;
+  if (foundModule) {
+    return electronPath;
+  }
+
   return null;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,6 @@ export const shouldRebuildNativeModules  = () => Promise.resolve(true);
 export const preGypFixRun = () => Promise.resolve();
 export { rebuild, rebuildNativeModules };
 export default rebuild;
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
   value: true
 });

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -35,11 +35,11 @@ class Rebuilder {
       public electronVersion: string,
       public arch = process.arch,
       public extraModules: string[] = [],
+      public onlyModules: string[] = [],
       public forceRebuild = false,
       public headerURL = 'https://atom.io/download/electron',
       public types = ['prod', 'optional'],
-      public mode = defaultMode,
-      public onlyModules: string[] = []) {
+      public mode = defaultMode) {
     this.ABI = nodeAbi.getAbi(electronVersion, 'electron');
     this.prodDeps = {};
     this.rebuilds = [];
@@ -255,15 +255,15 @@ export function rebuild(
     electronVersion: string,
     arch = process.arch,
     extraModules: string[] = [],
+    onlyModules: string[] = [],
     forceRebuild = false,
     headerURL = 'https://atom.io/download/electron',
     types = ['prod', 'optional'],
-    mode = defaultMode,
-    onlyModules: string[] = []) {
+    mode = defaultMode) {
 
   d('rebuilding with args:', arguments);
   const lifecycle = new EventEmitter();
-  const rebuilder = new Rebuilder(lifecycle, buildPath, electronVersion, arch, extraModules, forceRebuild, headerURL, types, mode, onlyModules);
+  const rebuilder = new Rebuilder(lifecycle, buildPath, electronVersion, arch, extraModules, onlyModules, forceRebuild, headerURL, types, mode);
 
   let ret = rebuilder.rebuild() as Promise<void> & { lifecycle: EventEmitter };
   ret.lifecycle = lifecycle;

--- a/test/electron-locater.ts
+++ b/test/electron-locater.ts
@@ -9,7 +9,7 @@ function packageCommand(command: string, packageName: string) {
   return spawnPromise('npm', [command, packageName], {
     cwd: path.resolve(__dirname, '..'),
     stdio: 'ignore',
-  })
+  });
 }
 
 const install: ((s: string) => Promise<void>) = packageCommand.bind(null, 'install');
@@ -24,7 +24,7 @@ const testElectronCanBeFound = () => {
 };
 
 describe('locateElectronPrebuilt', function() {
-  this.timeout(30*1000);
+  this.timeout(30 * 1000);
 
   before(() => uninstall('electron-prebuilt'));
 

--- a/test/read-package-json.ts
+++ b/test/read-package-json.ts
@@ -5,6 +5,6 @@ import { readPackageJson } from '../src/read-package-json';
 
 describe('read-package-json', () => {
   it('should find a package.json file from the given directory', async () => {
-    expect(await readPackageJson(path.resolve(__dirname, '..'))).to.deep.equal(require('../package.json'))
+    expect(await readPackageJson(path.resolve(__dirname, '..'))).to.deep.equal(require('../package.json'));
   });
 });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -15,7 +15,9 @@ describe('rebuilder', () => {
   const resetTestModule = async () => {
     await fs.remove(testModulePath);
     await fs.mkdirs(testModulePath);
-    await fs.writeFile(path.resolve(testModulePath, 'package.json'), await fs.readFile(path.resolve(__dirname, '../test/fixture/native-app1/package.json'), 'utf8'));
+    await fs.writeFile(
+      path.resolve(testModulePath, 'package.json'), await fs.readFile(path.resolve(__dirname, '../test/fixture/native-app1/package.json'), 'utf8')
+    );
     await spawnPromise('npm', ['install'], {
       cwd: testModulePath,
       stdio: 'inherit',


### PR DESCRIPTION
in my case `node-sass` was recompiling over and over again (2-3mins) and I couldn't provide option to build only modules I want (`-w`) or to ignore others. 
this fixes the behaviour of `-w` flag. 

closes issue: https://github.com/electron/electron-rebuild/issues/151
