### PR TITLE
Switch to passing args in an options object instead of one long chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import rebuild from 'electron-rebuild';
 packager({
   // … other options
   afterCopy: [(buildPath, electronVersion, platform, arch, callback) => {
-    rebuild(buildPath, electronVersion, arch)
+    rebuild({ buildPath, electronVersion, arch })
       .then(() => callback())
       .catch((error) => callback(error));
   }],
@@ -100,14 +100,15 @@ import rebuild from 'electron-rebuild';
 
 // Public: Rebuilds a node_modules directory with the given Electron version.
 //
-// appPath - An absolute path to your app's directory.  (The directory that contains your node_modules)
-// electronVersion - The version of Electron to rebuild for
-// arch (optional) - Default: process.arch - The arch to rebuild for
-// extraModules (optional) - Default: [] - An array of modules to rebuild as well as the detected modules
-// forceRebuild (optional) - Default: false - Force a rebuild of modules regardless of their current build state
-// headerURL (optional) - Default: atom.io/download/electron - The URL to download Electron header files from
-// types (optional) - Default: ['prod', 'optional'] - The types of modules to rebuild
-// mode (optional) - The rebuild mode, either 'sequential' or 'parallel' - Default varies per platform (probably shouldn't mess with this one)
+// options: Object with the following properties
+//     appPath - An absolute path to your app's directory.  (The directory that contains your node_modules)
+//     electronVersion - The version of Electron to rebuild for
+//     arch (optional) - Default: process.arch - The arch to rebuild for
+//     extraModules (optional) - Default: [] - An array of modules to rebuild as well as the detected modules
+//     force (optional) - Default: false - Force a rebuild of modules regardless of their current build state
+//     headerURL (optional) - Default: atom.io/download/electron - The URL to download Electron header files from
+//     types (optional) - Default: ['prod', 'optional'] - The types of modules to rebuild
+//     mode (optional) - The rebuild mode, either 'sequential' or 'parallel' - Default varies per platform (probably shouldn't mess with this one)
 
 // Returns a Promise indicating whether the operation succeeded or not
 ```
@@ -118,7 +119,10 @@ A full build process might look something like:
 let childProcess = require('child_process');
 let pathToElectron = require('electron-prebuilt');
 
-  rebuild(__dirname, '1.4.12')
+  rebuild({
+    buildPath: __dirname,
+    electronVersion: '1.4.12'
+  })
     .then(() => console.info('Rebuild Successful'))
     .catch((e) => {
       console.error("Building modules didn't work!");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,11 +4,12 @@ import 'colors';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as ora from 'ora';
+import * as argParser from 'yargs';
 
 import { rebuild } from './rebuild';
 import { locateElectronPrebuilt } from './electron-locater';
 
-const yargs = require('yargs')
+const yargs = argParser
   .usage('Usage: electron-rebuild --version [version] --module-dir [path]')
   .help('h')
   .alias('h', 'help')
@@ -57,7 +58,7 @@ process.on('unhandledRejection', handler);
 
   if (!electronPrebuiltVersion) {
     try {
-      if (!electronPrebuiltPath) throw new Error("electron-prebuilt not found");
+      if (!electronPrebuiltPath) throw new Error('electron-prebuilt not found');
       const pkgJson = require(path.join(electronPrebuiltPath, 'package.json'));
 
       electronPrebuiltVersion = pkgJson.version;
@@ -96,9 +97,18 @@ process.on('unhandledRejection', handler);
     } else {
       rebuildSpinner.text = `Building module: ${lastModuleName}, Completed: ${modulesDone}`;
     }
-  }
+  };
 
-  const rebuilder = rebuild(rootDirectory, electronPrebuiltVersion, argv.a || process.arch, argv.w ? argv.w.split(',') : [], argv.f, argv.d, argv.t ? argv.t.split(',') : ['prod', 'optional'], argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined));
+  const rebuilder = rebuild({
+    buildPath: rootDirectory,
+    electronVersion: electronPrebuiltVersion,
+    arch: argv.a || process.arch,
+    extraModules: argv.w ? argv.w.split(',') : [],
+    force: argv.f,
+    headerURL: argv.d,
+    types: argv.t ? argv.t.split(',') : ['prod', 'optional'],
+    mode: argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined)
+  });
 
   const lifecycle = rebuilder.lifecycle;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,6 @@ export const shouldRebuildNativeModules  = () => Promise.resolve(true);
 export const preGypFixRun = () => Promise.resolve();
 export { rebuild, rebuildNativeModules };
 export default rebuild;
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
   value: true
 });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -5,7 +5,7 @@ import * as ora from 'ora';
 
 import { spawnPromise } from 'spawn-rx';
 import { expect } from 'chai';
-import { rebuild } from '../src/rebuild';
+import { rebuild, RebuildOptions } from '../src/rebuild';
 
 ora.ora = ora;
 
@@ -15,57 +15,77 @@ describe('rebuilder', () => {
   const resetTestModule = async () => {
     await fs.remove(testModulePath);
     await fs.mkdirs(testModulePath);
-    await fs.writeFile(path.resolve(testModulePath, 'package.json'), await fs.readFile(path.resolve(__dirname, '../test/fixture/native-app1/package.json'), 'utf8'));
+    await fs.writeFile(
+      path.resolve(testModulePath, 'package.json'),
+      await fs.readFile(path.resolve(__dirname, '../test/fixture/native-app1/package.json'), 'utf8')
+    );
     await spawnPromise('npm', ['install'], {
       cwd: testModulePath,
-      stdio: 'inherit',
+      stdio: 'ignore',
     });
   };
 
-  describe('core behavior', function() {
-    this.timeout(2 * 60 * 1000);
+  const optionSets: {
+    name: string,
+    args: RebuildOptions | string[]
+  }[] = [
+    { args: [testModulePath, '1.4.12', process.arch], name: 'sequential args' },
+    { args: {
+      buildPath: testModulePath,
+      electronVersion: '1.4.12',
+      arch: process.arch
+    }, name: 'options object' }
+  ];
+  for (const options of optionSets) {
+    describe(`core behavior -- ${options.name}`, function() {
+      this.timeout(2 * 60 * 1000);
 
-    before(resetTestModule);
+      before(resetTestModule);
 
-    before(async () => {
-      await rebuild(testModulePath, '1.4.12', process.arch);
+      before(async () => {
+        let args: any = options.args;
+        if (!Array.isArray(args)) {
+          args = [args];
+        }
+        await (<any>rebuild)(...args);
+      });
+
+      it('should have rebuilt top level prod dependencies', async () => {
+        const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref', 'build', 'Release', '.forge-meta');
+        expect(await fs.exists(forgeMeta), 'ref build meta should exist').to.equal(true);
+      });
+
+      it('should not have rebuild top level prod dependencies that are prebuilt', async () => {
+        const forgeMeta = path.resolve(testModulePath, 'node_modules', 'sodium-native', 'build', 'Release', '.forge-meta');
+        expect(await fs.exists(forgeMeta), 'ref build meta should exist').to.equal(false);
+      });
+
+      it('should have rebuilt children of top level prod dependencies', async () => {
+        const forgeMetaGoodNPM = path.resolve(testModulePath, 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
+        const forgeMetaBadNPM = path.resolve(testModulePath, 'node_modules', 'benchr', 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
+        expect(await fs.exists(forgeMetaGoodNPM) || await fs.exists(forgeMetaBadNPM), 'microtime build meta should exist').to.equal(true);
+      });
+
+      it('should have rebuilt children of scoped top level prod dependencies', async () => {
+        const forgeMeta = path.resolve(testModulePath, 'node_modules', '@newrelic/native-metrics', 'build', 'Release', '.forge-meta');
+        expect(await fs.exists(forgeMeta), '@newrelic/native-metrics build meta should exist').to.equal(true);
+      });
+
+      it('should have rebuilt top level optional dependencies', async () => {
+        const forgeMeta = path.resolve(testModulePath, 'node_modules', 'zipfile', 'build', 'Release', '.forge-meta');
+        expect(await fs.exists(forgeMeta), 'zipfile build meta should exist').to.equal(true);
+      });
+
+      it('should not have rebuilt top level devDependencies', async () => {
+        const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ffi', 'build', 'Release', '.forge-meta');
+        expect(await fs.exists(forgeMeta), 'ffi build meta should not exist').to.equal(false);
+      });
+
+      after(async () => {
+        await fs.remove(testModulePath);
+      });
     });
-
-    it('should have rebuilt top level prod dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref', 'build', 'Release', '.forge-meta');
-      expect(await fs.exists(forgeMeta), 'ref build meta should exist').to.equal(true);
-    });
-
-    it('should not have rebuild top level prod dependencies that are prebuilt', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'sodium-native', 'build', 'Release', '.forge-meta');
-      expect(await fs.exists(forgeMeta), 'ref build meta should exist').to.equal(false);
-    });
-
-    it('should have rebuilt children of top level prod dependencies', async () => {
-      const forgeMetaGoodNPM = path.resolve(testModulePath, 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
-      const forgeMetaBadNPM = path.resolve(testModulePath, 'node_modules', 'benchr', 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
-      expect(await fs.exists(forgeMetaGoodNPM) || await fs.exists(forgeMetaBadNPM), 'microtime build meta should exist').to.equal(true);
-    });
-
-    it('should have rebuilt children of scoped top level prod dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', '@newrelic/native-metrics', 'build', 'Release', '.forge-meta');
-      expect(await fs.exists(forgeMeta), '@newrelic/native-metrics build meta should exist').to.equal(true);
-    });
-
-    it('should have rebuilt top level optional dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'zipfile', 'build', 'Release', '.forge-meta');
-      expect(await fs.exists(forgeMeta), 'zipfile build meta should exist').to.equal(true);
-    });
-
-    it('should not have rebuilt top level devDependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ffi', 'build', 'Release', '.forge-meta');
-      expect(await fs.exists(forgeMeta), 'ffi build meta should not exist').to.equal(false);
-    });
-
-    after(async () => {
-      await fs.remove(testModulePath);
-    });
-  });
+  }
 
   describe('force rebuild', function() {
     this.timeout(2 * 60 * 1000);

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "curly": true,
+    "curly": false,
     "eofline": false,
     "align": [true, "parameters"],
     "class-name": true,


### PR DESCRIPTION
This makes the `rebuild` API accept an options object instead of like 10 consecutive argument.

Gives us more control over the properties / arguments and lets us add things easier in the future in a non-breaking way.

Also note that this is a backwards compatible change (see the test file updates)