### PR TITLE
fix path must be string when no `*.node` files found

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -172,13 +172,13 @@ class Rebuilder {
 
     d('searching for .node file', path.resolve(modulePath, 'build/Release'));
     d('testing files', (await fs.readdir(path.resolve(modulePath, 'build/Release'))));
-    const nodePath = path.resolve(modulePath, 'build/Release',
-      (await fs.readdir(path.resolve(modulePath, 'build/Release')))
-        .find((file) => file !== '.node' && file.endsWith('.node'))
-      );
+
+    const nodeFile = (await fs.readdir(path.resolve(modulePath, 'build/Release')))
+      .find((file) => file !== '.node' && file.endsWith('.node'));
+    const nodePath = nodeFile ? path.resolve(modulePath, 'build/Release', nodeFile) : undefined;
 
     const abiPath = path.resolve(modulePath, `bin/${process.platform}-${this.arch}-${this.ABI}`);
-    if (await fs.exists(nodePath)) {
+    if (nodePath && await fs.exists(nodePath)) {
       d('found .node file', nodePath);
       d('copying to prebuilt place:', abiPath);
       await fs.mkdirs(abiPath);


### PR DESCRIPTION
I see this on Ubuntu 14.04.5 LTS. Turns out there are no `*.node` files for `fsevents`, and `electron-rebuild` breaks with `TypeError: Path must be a string. Received undefined`.

This fix just ensures that if there are no `*.node` files then we bow out gracefully.

```
electron-rebuild rebuilding: fsevents +81ms
electron-rebuild rebuilding fsevents with args [ 'rebuild',
'--target=1.6.11',
'--arch=x64',
'--dist-url=https://atom.io/download/electron',
'--build-from-source',
'--module_name=fse',
'--module_path=/home/rof/src/github.com/user/repo/node_modules/fsevents/lib/binding/Release/electron-v1.6-linux-x64',
'--remote_path=./v1.1.2/',
'--package_name=fse-v1.1.2-electron-v1.6-linux-x64.tar.gz',
'--host=https://fsevents-binaries.s3-us-west-2.amazonaws.com' ] +0ms
electron-rebuild built: fsevents +803ms
electron-rebuild searching for .node file /home/rof/src/github.com/user/repo/node_modules/fsevents/build/Release +2ms
electron-rebuild testing files [ '.deps', '.forge-meta', '.node', 'obj.target' ] +1ms
✖ Rebuild Failed
An unhandled error occurred inside electron-rebuild
Path must be a string. Received undefined

TypeError: Path must be a string. Received undefined
  at assertPath (path.js:28:11)
  at Object.resolve (path.js:1167:7)
  at Rebuilder.<anonymous> (/home/rof/src/github.com/user/repo/node_modules/electron-rebuild/lib/src/rebuild.js:151:35)
  at Generator.next (<anonymous>)
  at fulfilled (/home/rof/src/github.com/user/repo/node_modules/electron-rebuild/lib/src/rebuild.js:4:58)
  at <anonymous>
```