### PR TITLE
Add --only option to build whitelisted modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
                                on macOS and Linux
   -s, --sequential             Rebuild modules sequentially, this is enabled by
                                default on Windows
+  -o, --only                   Only build specified module, or comma separated
+                               list of modules. All others are ignored.
 
 Copyright 2016
 ```

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ import rebuild from 'electron-rebuild';
 //     electronVersion - The version of Electron to rebuild for
 //     arch (optional) - Default: process.arch - The arch to rebuild for
 //     extraModules (optional) - Default: [] - An array of modules to rebuild as well as the detected modules
+//     onlyModules (optional) - Default: null - An array of modules to rebuild, ONLY these module names will be rebuilt.
+//                                              The "types" property will be ignored if this option is set.
 //     force (optional) - Default: false - Force a rebuild of modules regardless of their current build state
 //     headerURL (optional) - Default: atom.io/download/electron - The URL to download Electron header files from
 //     types (optional) - Default: ['prod', 'optional'] - The types of modules to rebuild

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,8 @@ const yargs = argParser
   .alias('m', 'module-dir')
   .describe('w', 'A specific module to build, or comma separated list of modules')
   .alias('w', 'which-module')
+  .describe('o', 'Only build specified module, or comma separated list of modules. All others are ignored.')
+  .alias('o', 'only')
   .describe('e', 'The path to electron-prebuilt')
   .alias('e', 'electron-prebuilt-dir')
   .describe('d', 'Custom header tarball URL')
@@ -92,6 +94,7 @@ process.on('unhandledRejection', handler);
 
   const redraw = (moduleName?: string) => {
     if (moduleName) lastModuleName = moduleName;
+
     if (argv.p) {
       rebuildSpinner.text = `Building modules: ${modulesDone}/${moduleTotal}`;
     } else {
@@ -104,6 +107,7 @@ process.on('unhandledRejection', handler);
     electronVersion: electronPrebuiltVersion,
     arch: argv.a || process.arch,
     extraModules: argv.w ? argv.w.split(',') : [],
+    onlyModules: argv.o ? argv.o.split(',') : [],
     force: argv.f,
     headerURL: argv.d,
     types: argv.t ? argv.t.split(',') : ['prod', 'optional'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,7 @@ process.on('unhandledRejection', handler);
     electronVersion: electronPrebuiltVersion,
     arch: argv.a || process.arch,
     extraModules: argv.w ? argv.w.split(',') : [],
-    onlyModules: argv.o ? argv.o.split(',') : [],
+    onlyModules: argv.o ? argv.o.split(',') : null,
     force: argv.f,
     headerURL: argv.d,
     types: argv.t ? argv.t.split(',') : ['prod', 'optional'],

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -15,6 +15,7 @@ export interface RebuildOptions {
   electronVersion: string;
   arch?: string;
   extraModules?: string[];
+  onlyModules?: string[];
   force?: boolean;
   headerURL?: string;
   types?: ModuleType[];
@@ -55,6 +56,7 @@ class Rebuilder {
   public electronVersion: string;
   public arch: string;
   public extraModules: string[];
+  public onlyModules: string[];
   public force: boolean;
   public headerURL: string;
   public types: ModuleType[];
@@ -66,6 +68,7 @@ class Rebuilder {
     this.electronVersion = options.electronVersion;
     this.arch = options.arch || process.arch;
     this.extraModules = options.extraModules || [];
+    this.onlyModules = options.onlyModules || [];
     this.force = options.force || false;
     this.headerURL = options.headerURL || 'https://atom.io/download/electron';
     this.types = options.types || defaultTypes;
@@ -240,7 +243,8 @@ class Rebuilder {
       }
       this.realModulePaths.add(realPath);
 
-      if (this.prodDeps[`${prefix}${modulePath}`]) {
+      if (this.prodDeps[`${prefix}${modulePath}`] &&
+          this.onlyModules.length === 0 || this.onlyModules.includes(modulePath)) {
         this.rebuilds.push(() => this.rebuildModuleAt(realPath));
       }
 
@@ -310,7 +314,7 @@ function doRebuild(options: any, ...args: any[]) {
   if (typeof options === 'object') {
     return rebuildWithOptions(options as RebuildOptions);
   }
-  console.warn('You are using the depreceated electron-rebuild API, please switch to using the options object instead');
+  console.warn('You are using the deprecated electron-rebuild API, please switch to using the options object instead');
   return rebuildWithOptions((<Function>createOptions)(options, ...args));
 }
 
@@ -321,6 +325,7 @@ export type RebuildFunctionWithArgs = (
   electronVersion: string,
   arch?: string,
   extraModules?: string[],
+  onlyModules?: string[],
   force?: boolean,
   headerURL?: string,
   types?: ModuleType[],
@@ -335,6 +340,7 @@ export function createOptions(
     electronVersion: string,
     arch: string,
     extraModules: string[],
+    onlyModules: string[],
     force: boolean,
     headerURL: string,
     types: ModuleType[],
@@ -345,6 +351,7 @@ export function createOptions(
     electronVersion,
     arch,
     extraModules,
+    onlyModules,
     force,
     headerURL,
     types,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -315,7 +315,7 @@ function doRebuild(options: any, ...args: any[]) {
   if (typeof options === 'object') {
     return rebuildWithOptions(options as RebuildOptions);
   }
-  console.warn('You are using the deprecated electron-rebuild API, please switch to using the options object instead');
+  console.warn('You are using the depreceated electron-rebuild API, please switch to using the options object instead');
   return rebuildWithOptions((<Function>createOptions)(options, ...args));
 }
 

--- a/test/read-package-json.ts
+++ b/test/read-package-json.ts
@@ -5,6 +5,6 @@ import { readPackageJson } from '../src/read-package-json';
 
 describe('read-package-json', () => {
   it('should find a package.json file from the given directory', async () => {
-    expect(await readPackageJson(path.resolve(__dirname, '..'))).to.deep.equal(require('../package.json'))
+    expect(await readPackageJson(path.resolve(__dirname, '..'))).to.deep.equal(require('../package.json'));
   });
 });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -94,7 +94,7 @@ describe('rebuilder', () => {
 
     it('should skip the rebuild step when disabled', async () => {
       await rebuild(testModulePath, '1.4.12', process.arch);
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], false);
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], [], false);
       let skipped = 0;
       rebuilder.lifecycle.on('module-skip', () => {
         skipped++;
@@ -105,7 +105,7 @@ describe('rebuilder', () => {
 
     it('should rebuild all modules again when disabled but the electron ABI bumped', async () => {
       await rebuild(testModulePath, '1.4.12', process.arch);
-      const rebuilder = rebuild(testModulePath, '1.6.0', process.arch, [], false);
+      const rebuilder = rebuild(testModulePath, '1.6.0', process.arch, [], [], false);
       let skipped = 0;
       rebuilder.lifecycle.on('module-skip', () => {
         skipped++;
@@ -116,13 +116,36 @@ describe('rebuilder', () => {
 
     it('should rebuild all modules again when enabled', async () => {
       await rebuild(testModulePath, '1.4.12', process.arch);
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], true);
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], [], true);
       let skipped = 0;
       rebuilder.lifecycle.on('module-skip', () => {
         skipped++;
       });
       await rebuilder;
       expect(skipped).to.equal(0);
+    });
+  });
+
+  describe('only rebuild', function() {
+    this.timeout(2 * 60 * 1000);
+
+    beforeEach(resetTestModule);
+    afterEach(async () => await fs.remove(testModulePath));
+
+    it('should rebuild only specified modules', async () => {
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], ['ffi'], true);
+      let built = 0;
+      rebuilder.lifecycle.on('module-done', () => built++);
+      await rebuilder;
+      expect(built).to.equal(1);
+    });
+
+    it('should rebuild multiple specified modules via --only option', async () => {
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], ['ffi', '@newrelic/native-metrics'], true);
+      let built = 0;
+      rebuilder.lifecycle.on('module-done', () => built++);
+      await rebuilder;
+      expect(built).to.equal(2);
     });
   });
 });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -62,7 +62,9 @@ describe('rebuilder', () => {
 
       it('should have rebuilt children of top level prod dependencies', async () => {
         const forgeMetaGoodNPM = path.resolve(testModulePath, 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
-        const forgeMetaBadNPM = path.resolve(testModulePath, 'node_modules', 'benchr', 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
+        const forgeMetaBadNPM = path.resolve(
+          testModulePath, 'node_modules', 'benchr', 'node_modules', 'microtime', 'build', 'Release', '.forge-meta'
+        );
         expect(await fs.exists(forgeMetaGoodNPM) || await fs.exists(forgeMetaBadNPM), 'microtime build meta should exist').to.equal(true);
       });
 
@@ -94,7 +96,7 @@ describe('rebuilder', () => {
 
     it('should skip the rebuild step when disabled', async () => {
       await rebuild(testModulePath, '1.4.12', process.arch);
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], [], false);
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], false);
       let skipped = 0;
       rebuilder.lifecycle.on('module-skip', () => {
         skipped++;
@@ -105,7 +107,7 @@ describe('rebuilder', () => {
 
     it('should rebuild all modules again when disabled but the electron ABI bumped', async () => {
       await rebuild(testModulePath, '1.4.12', process.arch);
-      const rebuilder = rebuild(testModulePath, '1.6.0', process.arch, [], [], false);
+      const rebuilder = rebuild(testModulePath, '1.6.0', process.arch, [], false);
       let skipped = 0;
       rebuilder.lifecycle.on('module-skip', () => {
         skipped++;
@@ -116,7 +118,7 @@ describe('rebuilder', () => {
 
     it('should rebuild all modules again when enabled', async () => {
       await rebuild(testModulePath, '1.4.12', process.arch);
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], [], true);
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], true);
       let skipped = 0;
       rebuilder.lifecycle.on('module-skip', () => {
         skipped++;
@@ -133,7 +135,13 @@ describe('rebuilder', () => {
     afterEach(async () => await fs.remove(testModulePath));
 
     it('should rebuild only specified modules', async () => {
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], ['ffi'], true);
+      const rebuilder = rebuild({
+        buildPath: testModulePath,
+        electronVersion: '1.4.12',
+        arch: process.arch,
+        onlyModules: ['ffi'],
+        force: true
+      });
       let built = 0;
       rebuilder.lifecycle.on('module-done', () => built++);
       await rebuilder;
@@ -141,7 +149,13 @@ describe('rebuilder', () => {
     });
 
     it('should rebuild multiple specified modules via --only option', async () => {
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], ['ffi', 'ref'], true);
+      const rebuilder = rebuild({
+        buildPath: testModulePath,
+        electronVersion: '1.4.12',
+        arch: process.arch,
+        onlyModules: ['ffi', 'ref'],
+        force: true
+      });
       let built = 0;
       rebuilder.lifecycle.on('module-done', () => built++);
       await rebuilder;

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -141,7 +141,7 @@ describe('rebuilder', () => {
     });
 
     it('should rebuild multiple specified modules via --only option', async () => {
-      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], ['ffi', '@newrelic/native-metrics'], true);
+      const rebuilder = rebuild(testModulePath, '1.4.12', process.arch, [], ['ffi', 'ref'], true);
       let built = 0;
       rebuilder.lifecycle.on('module-done', () => built++);
       await rebuilder;


### PR DESCRIPTION
Adapted from changes originally in #178 (can be considered a replacement for that, with the additional benefit of handling nested module names).

Fixes #151

/cc @jkuri