### PR TITLE
Add `{libc}` token replacement and libc detection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "debug": "^2.6.3",
+    "detect-libc": "^1.0.3",
     "fs-extra": "^3.0.1",
     "node-abi": "^2.0.0",
     "node-gyp": "^3.6.0",

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,2 +1,3 @@
+declare module 'detect-libc';
 declare module 'ora';
 declare module 'node-abi';

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -1,5 +1,6 @@
 import { spawnPromise } from 'spawn-rx';
 import * as debug from 'debug';
+import * as detectLibc from 'detect-libc';
 import * as EventEmitter from 'events';
 import * as fs from 'fs-extra';
 import * as nodeAbi from 'node-abi';
@@ -195,7 +196,8 @@ class Rebuilder {
         .replace('{node_abi}', `electron-v${this.electronVersion.split('.').slice(0, 2).join('.')}`)
         .replace('{platform}', process.platform)
         .replace('{arch}', this.arch)
-        .replace('{version}', modulePackageJson.version);
+        .replace('{version}', modulePackageJson.version)
+        .replace('{libc}', detectLibc.family || 'unknown');
 
       Object.keys(modulePackageJson.binary).forEach((binaryReplaceKey) => {
         value = value.replace(`{${binaryReplaceKey}}`, modulePackageJson.binary[binaryReplaceKey]);


### PR DESCRIPTION
Fixes #217. `node-pre-gyp` added support for a new `{libc}` token which landed here: https://github.com/mapbox/node-pre-gyp/commit/db6ab8019123bdb07cce02bfb4f028dd382b87ff and was released in v0.6.39.

I notice that `electron-rebuild` has no `node-pre-gyp` dependency to update.