### PR TITLE
feat: add a caching option

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,133 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import * as zlib from 'zlib';
+
+class Snap {
+  constructor(public hash: string, public data: Buffer) {}
+}
+
+interface Snapshot {
+  [key: string]: Snap | Snapshot;
+}
+
+const takeSnapshot = async (dir: string, relativeTo = dir) => {
+  const snap: Snapshot = {};
+  await Promise.all((await fs.readdir(dir)).map(async (child) => {
+    if (child === 'node_modules') return;
+    const childPath = path.resolve(dir, child);
+    const relative = path.relative(relativeTo, childPath);
+    if ((await fs.stat(childPath)).isDirectory()) {
+      snap[relative] = await takeSnapshot(childPath, relativeTo);
+    } else {
+      const data = await fs.readFile(childPath);
+      snap[relative] = new Snap(
+        crypto.createHash('SHA256').update(data).digest('hex'),
+        data,
+      );
+    }
+  }));
+  return snap;
+};
+
+const calcDiff = (first: Snapshot, second: Snapshot) => {
+  const diff: Snapshot = {};
+  if (!first || !second) return diff;
+  for (const key in first) {
+    if (first[key] instanceof Snap && second[key] instanceof Snap) {
+      if ((first[key] as Snap).hash !== (second[key] as Snap).hash) {
+        diff[key] = second[key];
+      }
+    } else if (first[key] instanceof Snap) {
+      // Do nothing
+    } else if (second[key] instanceof Snap) {
+      diff[key] = second[key];
+    } else {
+      diff[key] = calcDiff(first[key] as Snapshot, second[key] as Snapshot);
+    }
+  }
+  for (const key in second) {
+    if (!first[key]) {
+      diff[key] = second[key];
+    }
+  }
+  return diff;
+};
+
+const writeDiff = async (diff: Snapshot, dir: string) => {
+  for (const key in diff) {
+    if (diff[key] instanceof Snap) {
+      await fs.mkdirp(path.dirname(path.resolve(dir, key)));
+      await fs.writeFile(path.resolve(dir, key), (diff[key] as Snap).data);
+    } else {
+      await fs.mkdirp(path.resolve(dir, key));
+      await writeDiff(diff[key] as Snapshot, dir);
+    }
+  }
+};
+
+const serialize = (snap: Snapshot) => {
+  const jsonReady: any = {};
+  for (const key in snap) {
+    if (snap[key] instanceof Snap) {
+      const s = snap[key] as Snap;
+      jsonReady[key] = {
+        __isSnap: true,
+        hash: s.hash,
+        data: s.data.toString('base64')
+      };
+    } else {
+      jsonReady[key] = serialize(snap[key] as Snapshot);
+    }
+  }
+  return jsonReady;
+};
+
+const unserialize = (jsonReady: any) => {
+  const snap: Snapshot = {};
+  for (const key in jsonReady) {
+    if (jsonReady[key].__isSnap) {
+      snap[key] = new Snap(
+        jsonReady[key].hash,
+        Buffer.from(jsonReady[key].data, 'base64')
+      );
+    } else {
+      snap[key] = unserialize(jsonReady[key]);
+    }
+  }
+  return snap;
+};
+
+export const prepare = async (dir: string) => {
+  const initial = await takeSnapshot(dir);
+  return async function collect(cachePath: string, key: string) {
+    const post = await takeSnapshot(dir);
+    const diff = await calcDiff(initial, post);
+    await fs.mkdirp(cachePath);
+    const moduleBuffer = Buffer.from(JSON.stringify(serialize(diff)));
+    const zipped = await new Promise(resolve => zlib.gzip(moduleBuffer, (_, result) => resolve(result)));
+    await fs.writeFile(path.resolve(cachePath, key), zipped);
+  };
+};
+
+export const cacheModuleState = async (dir: string, cachePath: string, key: string) => {
+  const snap = await takeSnapshot(dir);
+
+  const moduleBuffer = Buffer.from(JSON.stringify(serialize(snap)));
+  const zipped = await new Promise(resolve => zlib.gzip(moduleBuffer, (_, result) => resolve(result)));
+  await fs.mkdirp(cachePath);
+  await fs.writeFile(path.resolve(cachePath, key), zipped);
+};
+
+export const lookup = async (cachePath: string, key: string) => {
+  if (await fs.pathExists(path.resolve(cachePath, key))) {
+    return async function applyDiff(dir: string) {
+      const zipped = await fs.readFile(path.resolve(cachePath, key));
+      const unzipped = await new Promise(resolve => zlib.gunzip(zipped, (_, result) => resolve(result)));
+      const diff = unserialize(JSON.parse(unzipped.toString()));
+      await writeDiff(diff, dir);
+    };
+  }
+  return false;
+};

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -95,7 +95,7 @@ class Rebuilder {
     this.types = options.types || defaultTypes;
     this.mode = options.mode || defaultMode;
     this.debug = options.debug || false;
-    this.useCache = typeof options.useCache === 'undefined' ? true : options.useCache;
+    this.useCache = options.useCache || false;
     this.cachePath = options.cachePath || path.resolve(os.homedir(), '.electron-rebuild-cache');
 
     if (this.useCache && this.force) {

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -8,7 +8,7 @@ import * as nodeAbi from 'node-abi';
 import * as os from 'os';
 import * as path from 'path';
 import { readPackageJson } from './read-package-json';
-import { lookup, cacheModuleState } from './cache';
+import { lookupModuleState, cacheModuleState } from './cache';
 
 export type ModuleType = 'prod' | 'dev' | 'optional';
 export type RebuildMode = 'sequential' | 'parallel';
@@ -261,7 +261,7 @@ class Rebuilder {
         modulePath,
       });
 
-      const applyDiffFn = await lookup(this.cachePath, cacheKey);
+      const applyDiffFn = await lookupModuleState(this.cachePath, cacheKey);
       if (applyDiffFn) {
         await applyDiffFn(modulePath);
         this.lifecycle.emit('module-done');

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -1,4 +1,5 @@
 import { spawnPromise } from 'spawn-rx';
+import * as crypto from 'crypto';
 import * as debug from 'debug';
 import * as detectLibc from 'detect-libc';
 import * as EventEmitter from 'events';
@@ -7,6 +8,7 @@ import * as nodeAbi from 'node-abi';
 import * as os from 'os';
 import * as path from 'path';
 import { readPackageJson } from './read-package-json';
+import { lookup, cacheModuleState } from './cache';
 
 export type ModuleType = 'prod' | 'dev' | 'optional';
 export type RebuildMode = 'sequential' | 'parallel';
@@ -22,7 +24,11 @@ export interface RebuildOptions {
   types?: ModuleType[];
   mode?: RebuildMode;
   debug?: boolean;
+  useCache?: boolean;
+  cachePath?: string;
 }
+
+export type HashTree = { [path: string]: string | HashTree };
 
 export interface RebuilderOptions extends RebuildOptions {
   lifecycle: EventEmitter;
@@ -32,6 +38,8 @@ const d = debug('electron-rebuild');
 
 const defaultMode: RebuildMode = process.platform === 'win32' ? 'sequential' : 'parallel';
 const defaultTypes: ModuleType[] = ['prod', 'optional'];
+// Update this number if you change the caching logic to ensure no bad cache hits
+const ELECTRON_REBUILD_CACHE_ID = 1;
 
 const locateBinary = async (basePath: string, suffix: string) => {
   let testPath = basePath;
@@ -72,6 +80,8 @@ class Rebuilder {
   public types: ModuleType[];
   public mode: RebuildMode;
   public debug: boolean;
+  public useCache: boolean;
+  public cachePath: string;
 
   constructor(options: RebuilderOptions) {
     this.lifecycle = options.lifecycle;
@@ -85,6 +95,13 @@ class Rebuilder {
     this.types = options.types || defaultTypes;
     this.mode = options.mode || defaultMode;
     this.debug = options.debug || false;
+    this.useCache = typeof options.useCache === 'undefined' ? true : options.useCache;
+    this.cachePath = options.cachePath || path.resolve(os.homedir(), '.electron-rebuild-cache');
+
+    if (this.useCache && this.force) {
+      console.warn('[WARNING]: Electron Rebuild has force enabled and cache enabled, force take precedence and the cache will not be used.');
+      this.useCache = false;
+    }
 
     if (typeof this.electronVersion === 'number') {
       if (`${this.electronVersion}`.split('.').length === 1) {
@@ -157,6 +174,54 @@ class Rebuilder {
     }
   }
 
+  private hashDirectory = async (dir: string, relativeTo = dir) => {
+    d('hashing dir', dir);
+    const dirTree: HashTree = {};
+    await Promise.all((await fs.readdir(dir)).map(async (child) => {
+      d('found child', child, 'in dir', dir);
+      // Ignore output directories
+      if (dir === relativeTo && (child === 'build' || child === 'bin')) return;
+      // Don't hash nested node_modules
+      if (child === 'node_modules') return;
+
+      const childPath = path.resolve(dir, child);
+      const relative = path.relative(relativeTo, childPath);
+      if ((await fs.stat(childPath)).isDirectory()) {
+        dirTree[relative] = await this.hashDirectory(childPath, relativeTo);
+      } else {
+        dirTree[relative] = crypto.createHash('SHA256').update(await fs.readFile(childPath)).digest('hex');
+      }
+    }));
+    return dirTree;
+  }
+
+  private dHashTree = (tree: HashTree, hash: crypto.Hash) => {
+    for (const key of Object.keys(tree).sort()) {
+      hash.update(key);
+      if (typeof tree[key] === 'string') {
+        hash.update(tree[key] as string);
+      } else {
+        this.dHashTree(tree[key] as HashTree, hash);
+      }
+    }
+  }
+
+  private generateCacheKey = async (opts: { modulePath: string }) => {
+    const tree = await this.hashDirectory(opts.modulePath);
+    const hasher = crypto.createHash('SHA256')
+      .update(`${ELECTRON_REBUILD_CACHE_ID}`)
+      .update(path.basename(opts.modulePath))
+      .update(this.ABI)
+      .update(this.arch)
+      .update(this.debug ? 'debug' : 'not debug')
+      .update(this.headerURL)
+      .update(this.electronVersion);
+    this.dHashTree(tree, hasher);
+    const hash = hasher.digest('hex');
+    d('calculated hash of', opts.modulePath, 'to be', hash);
+    return hash;
+  }
+
   async rebuildModuleAt(modulePath: string) {
     if (!(await fs.exists(path.resolve(modulePath, 'binding.gyp')))) {
       return;
@@ -190,6 +255,20 @@ class Rebuilder {
       return;
     }
 
+    let cacheKey!: string;
+    if (this.useCache) {
+      cacheKey = await this.generateCacheKey({
+        modulePath,
+      });
+
+      const applyDiffFn = await lookup(this.cachePath, cacheKey);
+      if (applyDiffFn) {
+        await applyDiffFn(modulePath);
+        this.lifecycle.emit('module-done');
+        return;
+      }
+    }
+
     const modulePackageJson = await readPackageJson(modulePath);
 
     if ((modulePackageJson.dependencies || {})['prebuild-install']) {
@@ -221,6 +300,10 @@ class Rebuilder {
           d('built:', path.basename(modulePath));
           await fs.mkdirs(path.dirname(metaPath));
           await fs.writeFile(metaPath, metaData);
+          if (this.useCache) {
+            await cacheModuleState(modulePath, this.cachePath, cacheKey);
+          }
+          this.lifecycle.emit('module-done');
           return;
         }
       } else {
@@ -261,6 +344,10 @@ class Rebuilder {
       rebuildArgs.push(`--${binaryKey}=${value}`);
     });
 
+    if (process.env.GYP_MSVS_VERSION) {
+      rebuildArgs.push(`--msvs_version=${process.env.GYP_MSVS_VERSION}`);
+    }
+
     d('rebuilding', path.basename(modulePath), 'with args', rebuildArgs);
     await spawnPromise(nodeGypPath, rebuildArgs, {
       cwd: modulePath,
@@ -298,6 +385,9 @@ class Rebuilder {
       await fs.copy(nodePath, path.resolve(abiPath, `${moduleName}.node`));
     }
 
+    if (this.useCache) {
+      await cacheModuleState(modulePath, this.cachePath, cacheKey);
+    }
     this.lifecycle.emit('module-done');
   }
 


### PR DESCRIPTION
* Generates a deterministic hash of each directory being rebuilt
  * hash is based on options passed to electron-rebuild and contents of
    directory
* Checks if a cache entry exists for that hash
* If not, builds like normal
  * Then stores the entire state of that module directory as a gzipped
    blob in the users cache directory
* If yes, pulls the module directory state and applies it directly to
  that module

 Please note that this is kinda experimental, I would NOT reccomend using
 it on CI, but for local dev where rebuilding modules constantly can get
 very annoying I would 100% reccomend using it.

This is delibrately being left undocumented so it can stablize a bit or
potentially be removed at any point.