### PR TITLE
update node-abi 's version to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "debug": "^2.6.3",
     "detect-libc": "^1.0.3",
     "fs-extra": "^3.0.1",
-    "node-abi": "^2.0.0",
+    "node-abi": "^2.5.0",
     "node-gyp": "^3.6.0",
     "ora": "^1.2.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
when i update my electron version to 3.6.0, and excute `electron-rebuild` ,
I am struggling with the error:
`Could not detect abi for version 3.0.6 and runtime electron.  Updating "node-abi" might help solve this issue if it is a new release of electron`