### PR TITLE
feat: add --prebuild-tag-prefix option for prebuild-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Options:
   -o, --only                   Only build specified module, or comma separated
                                list of modules. All others are ignored.
   -b, --debug                  Build debug version of modules
+  -tp, --prebuild-tag-prefix   github tag prefix, default is "v", passed to prebuild-install
 
 Copyright 2016
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Options:
   -o, --only                   Only build specified module, or comma separated
                                list of modules. All others are ignored.
   -b, --debug                  Build debug version of modules
-  -ptp, --prebuild-tag-prefix  GitHub tag prefix passed to prebuild-install.
+  --prebuild-tag-prefix        GitHub tag prefix passed to prebuild-install.
                                Default is "v"
 
 Copyright 2016

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Options:
   -o, --only                   Only build specified module, or comma separated
                                list of modules. All others are ignored.
   -b, --debug                  Build debug version of modules
-  -tp, --prebuild-tag-prefix   GitHub tag prefix passed to prebuild-install.
+  -ptp, --prebuild-tag-prefix  GitHub tag prefix passed to prebuild-install.
                                Default is "v"
 
 Copyright 2016

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Options:
   -o, --only                   Only build specified module, or comma separated
                                list of modules. All others are ignored.
   -b, --debug                  Build debug version of modules
-  -tp, --prebuild-tag-prefix   github tag prefix, default is "v", passed to prebuild-install
+  -tp, --prebuild-tag-prefix   GitHub tag prefix passed to prebuild-install.
+                               Default is "v"
 
 Copyright 2016
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ const yargs = argParser
   .alias('s', 'sequential')
   .describe('b', 'Build debug version of modules')
   .alias('b','debug')
-  .describe('tp', 'github tag prefix, default is "v", passed to prebuild-install')
+  .describe('tp', 'GitHub tag prefix passed to prebuild-install. Default is "v"')
   .alias('tp', 'prebuild-tag-prefix')
   .epilog('Copyright 2016');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,8 @@ const yargs = argParser
   .alias('s', 'sequential')
   .describe('b', 'Build debug version of modules')
   .alias('b','debug')
+  .describe('tp', 'github tag prefix, default is "v", passed to prebuild-install')
+  .alias('tp', 'prebuild-tag-prefix')
   .epilog('Copyright 2016');
 
 const argv = yargs.argv;
@@ -125,7 +127,8 @@ process.on('unhandledRejection', handler);
     headerURL: argv.d as string,
     types: argv.t ? (argv.t as string).split(',') as ModuleType[] : ['prod', 'optional'],
     mode: argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined),
-    debug: argv.b as boolean
+    debug: argv.b as boolean,
+    tagPrefix: argv.tp || 'v',
   });
 
   const lifecycle = rebuilder.lifecycle;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,8 +38,7 @@ const yargs = argParser
   .alias('s', 'sequential')
   .describe('b', 'Build debug version of modules')
   .alias('b','debug')
-  .describe('ptp', 'GitHub tag prefix passed to prebuild-install. Default is "v"')
-  .alias('ptp', 'prebuild-tag-prefix')
+  .describe('prebuild-tag-prefix', 'GitHub tag prefix passed to prebuild-install. Default is "v"')
   .epilog('Copyright 2016');
 
 const argv = yargs.argv;
@@ -128,7 +127,7 @@ process.on('unhandledRejection', handler);
     types: argv.t ? (argv.t as string).split(',') as ModuleType[] : ['prod', 'optional'],
     mode: argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined),
     debug: argv.b as boolean,
-    prebuildTagPrefix: (argv.tp as string) || 'v',
+    prebuildTagPrefix: (argv.prebuildTagPrefix as string) || 'v',
   });
 
   const lifecycle = rebuilder.lifecycle;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,8 +38,8 @@ const yargs = argParser
   .alias('s', 'sequential')
   .describe('b', 'Build debug version of modules')
   .alias('b','debug')
-  .describe('tp', 'GitHub tag prefix passed to prebuild-install. Default is "v"')
-  .alias('tp', 'prebuild-tag-prefix')
+  .describe('ptp', 'GitHub tag prefix passed to prebuild-install. Default is "v"')
+  .alias('ptp', 'prebuild-tag-prefix')
   .epilog('Copyright 2016');
 
 const argv = yargs.argv;
@@ -128,7 +128,7 @@ process.on('unhandledRejection', handler);
     types: argv.t ? (argv.t as string).split(',') as ModuleType[] : ['prod', 'optional'],
     mode: argv.p ? 'parallel' : (argv.s ? 'sequential' : undefined),
     debug: argv.b as boolean,
-    tagPrefix: argv.tp || 'v',
+    prebuildTagPrefix: (argv.tp as string) || 'v',
   });
 
   const lifecycle = rebuilder.lifecycle;

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -26,6 +26,7 @@ export interface RebuildOptions {
   debug?: boolean;
   useCache?: boolean;
   cachePath?: string;
+  tagPrefix?: string;
 }
 
 export type HashTree = { [path: string]: string | HashTree };
@@ -82,6 +83,7 @@ class Rebuilder {
   public debug: boolean;
   public useCache: boolean;
   public cachePath: string;
+  public tagPrefix: string;
 
   constructor(options: RebuilderOptions) {
     this.lifecycle = options.lifecycle;
@@ -97,6 +99,7 @@ class Rebuilder {
     this.debug = options.debug || false;
     this.useCache = options.useCache || false;
     this.cachePath = options.cachePath || path.resolve(os.homedir(), '.electron-rebuild-cache');
+    this.tagPrefix = options.tagPrefix || 'v';
 
     if (this.useCache && this.force) {
       console.warn('[WARNING]: Electron Rebuild has force enabled and cache enabled, force take precedence and the cache will not be used.');
@@ -288,7 +291,8 @@ class Rebuilder {
               `--arch=${this.arch}`,
               `--platform=${process.platform}`,
               '--runtime=electron',
-              `--target=${this.electronVersion}`
+              `--target=${this.electronVersion}`,
+              `--tag-prefix=${this.tagPrefix}`
             ],
             {
               cwd: modulePath,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -26,7 +26,7 @@ export interface RebuildOptions {
   debug?: boolean;
   useCache?: boolean;
   cachePath?: string;
-  tagPrefix?: string;
+  prebuildTagPrefix?: string;
 }
 
 export type HashTree = { [path: string]: string | HashTree };
@@ -83,7 +83,7 @@ class Rebuilder {
   public debug: boolean;
   public useCache: boolean;
   public cachePath: string;
-  public tagPrefix: string;
+  public prebuildTagPrefix: string;
 
   constructor(options: RebuilderOptions) {
     this.lifecycle = options.lifecycle;
@@ -99,7 +99,7 @@ class Rebuilder {
     this.debug = options.debug || false;
     this.useCache = options.useCache || false;
     this.cachePath = options.cachePath || path.resolve(os.homedir(), '.electron-rebuild-cache');
-    this.tagPrefix = options.tagPrefix || 'v';
+    this.prebuildTagPrefix = options.prebuildTagPrefix || 'v';
 
     if (this.useCache && this.force) {
       console.warn('[WARNING]: Electron Rebuild has force enabled and cache enabled, force take precedence and the cache will not be used.');
@@ -292,7 +292,7 @@ class Rebuilder {
               `--platform=${process.platform}`,
               '--runtime=electron',
               `--target=${this.electronVersion}`,
-              `--tag-prefix=${this.tagPrefix}`
+              `--tag-prefix=${this.prebuildTagPrefix}`
             ],
             {
               cwd: modulePath,


### PR DESCRIPTION
* passes through --prebuilt-tag-prefix option to prebuild-install call to get
scoped modules from github

This will help [unblock users of `node-serialport`](https://github.com/node-serialport/node-serialport/issues/1672#issuecomment-448016260) to use the latest prebuilt binaries and any other package that uses custom tag prefixes with electron-rebuild. 