### PR TITLE
chore: use prepare instead of prepublish in package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "compile": "tsc",
     "watch": "tsc -w",
-    "prepublish": "npm run compile",
+    "prepare": "npm run compile",
     "mocha": "cross-env TS_NODE_FILES=true mocha --require ts-node/register ./test/*.ts",
     "lint": "tslint --project tsconfig.json --exclude \"test/**/node_modules/**/*.ts\" \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "npm run lint && npm run mocha"


### PR DESCRIPTION
This should allow installation when installing electron-rebuild from git.