### PR TITLE
Disable yargs' automatic --version command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ const yargs = argParser
   .usage('Usage: electron-rebuild --version [version] --module-dir [path]')
   .help('h')
   .alias('h', 'help')
+  .version(false)
   .describe('v', 'The version of Electron to build against')
   .alias('v', 'version')
   .describe('f', 'Force rebuilding modules, even if we would skip it otherwise')


### PR DESCRIPTION
👋 I found a tiny bug in the argument parsing. By default, yargs automatically installs its own `--version` command and processes it before electron-rebuild has a chance to process it itself. (It looks like this was introduced in [yargs 9.0.0](https://github.com/yargs/yargs/blob/master/CHANGELOG.md#900-2017-09-03).) By calling [`.version(false)`](http://yargs.js.org/docs/#api-versionversionboolean) explicitly, we can disable this and ensure that it's interpreted properly.

Before:

```
> electron-rebuild --help
Usage: electron-rebuild --version [version] --module-dir [path]

Options:
  -h, --help                   Show help                               [boolean]
  -v, --version                Show version number                     [boolean]
  -f, --force                  Force rebuilding modules, even if we would skip
                               it otherwise
  -a, --arch                   Override the target architecture to something
                               other than your system's
  -m, --module-dir             The path to the node_modules directory to rebuild
  -w, --which-module           A specific module to build, or comma separated
                               list of modules
  -o, --only                   Only build specified module, or comma separated
                               list of modules. All others are ignored.
  -e, --electron-prebuilt-dir  The path to electron-prebuilt
  -d, --dist-url               Custom header tarball URL
  -t, --types                  The types of dependencies to rebuild.  Comma
                               seperated list of "prod", "dev" and "optional".
                               Default is "prod,optional"
  -p, --parallel               Rebuild in parallel, this is enabled by default
                               on macOS and Linux
  -s, --sequential             Rebuild modules sequentially, this is enabled by
                               default on Windows
  -b, --debug                  Build debug version of modules

Copyright 2016

> electron-rebuild --version 3.0.14
1.8.3
```

After:

```
> electron-rebuild --help
Usage: electron-rebuild --version [version] --module-dir [path]

Options:
  -h, --help                   Show help                               [boolean]
  -v, --version                The version of Electron to build against
  -f, --force                  Force rebuilding modules, even if we would skip
                               it otherwise
  -a, --arch                   Override the target architecture to something
                               other than your system's
  -m, --module-dir             The path to the node_modules directory to rebuild
  -w, --which-module           A specific module to build, or comma separated
                               list of modules
  -o, --only                   Only build specified module, or comma separated
                               list of modules. All others are ignored.
  -e, --electron-prebuilt-dir  The path to electron-prebuilt
  -d, --dist-url               Custom header tarball URL
  -t, --types                  The types of dependencies to rebuild.  Comma
                               seperated list of "prod", "dev" and "optional".
                               Default is "prod,optional"
  -p, --parallel               Rebuild in parallel, this is enabled by default
                               on macOS and Linux
  -s, --sequential             Rebuild modules sequentially, this is enabled by
                               default on Windows
  -b, --debug                  Build debug version of modules

Copyright 2016

> electron-rebuild --version 3.0.14
√ Rebuild Complete
```