### PR TITLE
Use default export ora in src/cli.ts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import 'colors';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as ora from 'ora';
+import ora from 'ora';
 import * as argParser from 'yargs';
 
 import { rebuild, ModuleType } from './rebuild';


### PR DESCRIPTION
I was seeing:

```sh
> electron-rebuild@1.8.4 compile /path/electron-rebuild
> tsc

src/cli.ts:104:26 - error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("/path/electron-rebuild/node_modules/ora/index")' has no compatible call signatures.

104   const rebuildSpinner = ora('Searching dependency tree').start();
```

I'm not sure why this didn't fail in your CI.  Please close if it happens to fail.

I'm not sure what import ordering you prefer here, or why this doesn't error in your CI.