### PR TITLE
chore: use the new electronjs.org headers URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -562,9 +562,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.43",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.43.tgz",
-          "integrity": "sha512-5m5W13HR2k3cu88mpzlnPBBv5+GyMHtj4F0P83RG4mqoC0AYVYHVMHfF3SgwKNtqEZiZQASMxU92QsLEekKcnw==",
+          "version": "8.10.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
+          "integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
           "dev": true
         }
       }
@@ -2150,9 +2150,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "speedometer": {

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -91,7 +91,7 @@ class Rebuilder {
     this.extraModules = options.extraModules || [];
     this.onlyModules = options.onlyModules || null;
     this.force = options.force || false;
-    this.headerURL = options.headerURL || 'https://atom.io/download/electron';
+    this.headerURL = options.headerURL || 'https://electronjs.org/headers';
     this.types = options.types || defaultTypes;
     this.mode = options.mode || defaultMode;
     this.debug = options.debug || false;
@@ -359,7 +359,7 @@ class Rebuilder {
       cwd: modulePath,
       env: Object.assign({}, process.env, {
         USERPROFILE: path.resolve(os.homedir(), '.electron-gyp'),
-        npm_config_disturl: 'https://atom.io/download/electron',
+        npm_config_disturl: 'https://electronjs.org/headers',
         npm_config_runtime: 'electron',
         npm_config_arch: this.arch,
         npm_config_target_arch: this.arch,


### PR DESCRIPTION
We should be using the Electron JS redirect rather than the one on the Atom website