### PR TITLE
Update node-gyp for VS 2019 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "detect-libc": "^1.0.3",
     "fs-extra": "^7.0.1",
     "node-abi": "^2.8.0",
-    "node-gyp": "^4.0.0",
+    "node-gyp": "^5.0.3",
     "ora": "^3.4.0",
     "spawn-rx": "^3.0.0",
     "yargs": "^13.2.2"


### PR DESCRIPTION
The newest version of node-gyp supports Visual Studio 2019, however the version currently used by this module does not. Without this update windows users cannot use electron-rebuild if they have Visual Studio 2019 installed.