### PR TITLE
test: replace electron-markdown/cmark-gfm with level/leveldown

### DIFF
--- a/test/fixture/native-app1/package.json
+++ b/test/fixture/native-app1/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@nlv8/signun": "1.3.4",
     "farmhash": "3.0.0",
-    "electron-markdown": "0.6.0",
+    "level": "6.0.0",
     "ref-napi": "1.4.2"
   },
   "optionalDependencies": {

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -60,11 +60,11 @@ describe('rebuilder', () => {
       });
 
       it('should have rebuilt children of top level prod dependencies', async () => {
-        const forgeMetaGoodNPM = path.resolve(testModulePath, 'node_modules', 'cmark-gfm', 'build', 'Release', '.forge-meta');
+        const forgeMetaGoodNPM = path.resolve(testModulePath, 'node_modules', 'leveldown', 'build', 'Release', '.forge-meta');
         const forgeMetaBadNPM = path.resolve(
-          testModulePath, 'node_modules', 'electron-markdown', 'node_modules', 'cmark-gfm', 'build', 'Release', '.forge-meta'
+          testModulePath, 'node_modules', 'electron-markdown', 'node_modules', 'leveldown', 'build', 'Release', '.forge-meta'
         );
-        expect(await fs.pathExists(forgeMetaGoodNPM) || await fs.pathExists(forgeMetaBadNPM), 'cmark-gfm build meta should exist').to.equal(true);
+        expect(await fs.pathExists(forgeMetaGoodNPM) || await fs.pathExists(forgeMetaBadNPM), 'leveldown build meta should exist').to.equal(true);
       });
 
       it('should have rebuilt children of scoped top level prod dependencies', async () => {


### PR DESCRIPTION
`cmark-gfm` [no longer builds](https://app.circleci.com/jobs/github/electron/electron-rebuild/291), I think due to a change in N-API. So, I've replaced it with `leveldown`.