### PR TITLE
fix: remove one layer of HTTP redirects for Electron headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ import rebuild from 'electron-rebuild';
 //     onlyModules (optional) - Default: null - An array of modules to rebuild, ONLY these module names will be rebuilt.
 //                                              The "types" property will be ignored if this option is set.
 //     force (optional) - Default: false - Force a rebuild of modules regardless of their current build state
-//     headerURL (optional) - Default: https://electronjs.org/headers - The URL to download Electron header files from
+//     headerURL (optional) - Default: https://www.electronjs.org/headers - The URL to download Electron header files from
 //     types (optional) - Default: ['prod', 'optional'] - The types of modules to rebuild
 //     mode (optional) - The rebuild mode, either 'sequential' or 'parallel' - Default varies per platform (probably shouldn't mess with this one)
 

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -96,7 +96,7 @@ class Rebuilder {
     this.extraModules = options.extraModules || [];
     this.onlyModules = options.onlyModules || null;
     this.force = options.force || false;
-    this.headerURL = options.headerURL || 'https://electronjs.org/headers';
+    this.headerURL = options.headerURL || 'https://www.electronjs.org/headers';
     this.types = options.types || defaultTypes;
     this.mode = options.mode || defaultMode;
     this.debug = options.debug || false;
@@ -388,7 +388,7 @@ class Rebuilder {
       /* eslint-disable @typescript-eslint/camelcase */
       env: Object.assign({}, process.env, {
         USERPROFILE: path.resolve(os.homedir(), '.electron-gyp'),
-        npm_config_disturl: 'https://electronjs.org/headers',
+        npm_config_disturl: 'https://www.electronjs.org/headers',
         npm_config_runtime: 'electron',
         npm_config_arch: this.arch,
         npm_config_target_arch: this.arch,


### PR DESCRIPTION
When you try to retrieve headers via `https://electronjs.org/headers/v4.0.8/node-v4.0.8-headers.tar.gz`, it will cause the following HTTP response chain:

* `301 ➡️ https://www.electronjs.org/headers/v4.0.8/node-v4.0.8-headers.tar.gz`
* `302 ➡️ [S3 bucket URL]`
* `200`

We should save folks an HTTP request when they rebuild modules.