### PR TITLE
refactor: use node-gyp as a module instead of shelling out

### DIFF
--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -59,22 +59,6 @@ export class ModuleRebuilder {
     return path.basename(this.modulePath);
   }
 
-  get nodeGypEnv(): Record<string, string> {
-    /* eslint-disable @typescript-eslint/camelcase */
-    return {
-      ...process.env,
-      USERPROFILE: path.resolve(os.homedir(), '.electron-gyp'),
-      npm_config_disturl: 'https://www.electronjs.org/headers',
-      npm_config_runtime: 'electron',
-      npm_config_arch: this.rebuilder.arch,
-      npm_config_target_arch: this.rebuilder.arch,
-      npm_config_build_from_source: 'true',
-      npm_config_debug: this.rebuilder.debug ? 'true' : '',
-      npm_config_devdir: path.resolve(os.homedir(), '.electron-gyp'),
-    }
-    /* eslint-enable @typescript-eslint/camelcase */
-  }
-
   async alreadyBuiltByRebuild(): Promise<boolean> {
     if (await fs.pathExists(this.metaPath)) {
       const meta = await fs.readFile(this.metaPath, 'utf8');
@@ -89,10 +73,12 @@ export class ModuleRebuilder {
       'node',
       'node-gyp',
       'rebuild',
+      `--runtime=electron`,
       `--target=${this.rebuilder.electronVersion}`,
       `--arch=${this.rebuilder.arch}`,
       `--dist-url=${this.rebuilder.headerURL}`,
       '--build-from-source',
+      `--devdir="${path.resolve(os.homedir(), '.electron-gyp')}"`
     ];
 
     if (this.rebuilder.debug) {

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -131,7 +131,7 @@ export class ModuleRebuilder {
         .replace('{node_abi}', `electron-v${this.rebuilder.electronVersion.split('.').slice(0, 2).join('.')}`)
         .replace('{platform}', process.platform)
         .replace('{arch}', this.rebuilder.arch)
-        .replace('{version}', await this.packageJSONField('version'))
+        .replace('{version}', await this.packageJSONField('version') as string)
         .replace('{libc}', detectLibc.family || 'unknown');
 
       for (const [replaceKey, replaceValue] of Object.entries(binary)) {

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -30,11 +30,11 @@ async function locateNodeGyp(): Promise<string | null> {
   }
 
   return nodeGypPath;
-};
+}
 
-const locatePrebuild = async (modulePath: string): Promise<string | null> => {
+async function locatePrebuild(modulePath: string): Promise<string | null> {
   return await locateBinary(modulePath, 'node_modules/prebuild-install/bin.js');
-};
+}
 
 export enum BuildType {
   Debug = 'Debug',
@@ -67,7 +67,7 @@ export class ModuleRebuilder {
     return path.basename(this.modulePath);
   }
 
-  get nodeGypEnv() {
+  get nodeGypEnv(): Record<string, string> {
     /* eslint-disable @typescript-eslint/camelcase */
     return {
       ...process.env,
@@ -92,7 +92,7 @@ export class ModuleRebuilder {
     return false;
   }
 
-  async buildNodeGypArgs() {
+  async buildNodeGypArgs(): Promise<string[]> {
     const args = [
       'rebuild',
       `--target=${this.rebuilder.electronVersion}`,
@@ -144,7 +144,7 @@ export class ModuleRebuilder {
     return flags.filter(value => value) as string[];
   }
 
-  async cacheModuleState(cacheKey: string) {
+  async cacheModuleState(cacheKey: string): Promise<void> {
     if (this.rebuilder.useCache) {
       await cacheModuleState(this.modulePath, this.rebuilder.cachePath, cacheKey);
     }
@@ -155,7 +155,7 @@ export class ModuleRebuilder {
     return !!dependencies['prebuild-install']
   }
 
-  async packageJSONField(key: string, defaultValue?: any): Promise<any> {
+  async packageJSONField(key: string, defaultValue?: string | object): Promise<string | object> {
     if (!this.packageJSON) {
       this.packageJSON = await readPackageJson(this.modulePath);
     }
@@ -198,7 +198,7 @@ export class ModuleRebuilder {
   }
 
   async rebuildPrebuildModule(cacheKey: string): Promise<boolean> {
-    if (!(await this.rebuildPrebuildModule())) {
+    if (!(await this.isPrebuildNativeModule())) {
       return false;
     }
 
@@ -242,7 +242,7 @@ export class ModuleRebuilder {
     return false;
   }
 
-  async replaceExistingNativeModule() {
+  async replaceExistingNativeModule(): Promise<void> {
     const buildLocation = path.resolve(this.modulePath, 'build', this.buildType);
 
     d('searching for .node file', buildLocation);
@@ -261,7 +261,7 @@ export class ModuleRebuilder {
     }
   }
 
-  async writeMetadata() {
+  async writeMetadata(): Promise<void> {
     await fs.ensureDir(path.dirname(this.metaPath));
     await fs.writeFile(this.metaPath, this.metaData);
   }

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -8,7 +8,7 @@ import { readPackageJson } from './read-package-json';
 import { Rebuilder } from './rebuild';
 import { spawn } from '@malept/cross-spawn-promise';
 
-const d = debug('electron-windows-installer:module-rebuilder');
+const d = debug('electron-rebuild');
 
 const locateBinary = async (basePath: string, suffix: string): Promise<string | null> => {
   let testPath = basePath;

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -182,24 +182,8 @@ export class ModuleRebuilder {
     if (prebuildInstallPath) {
       d(`triggering prebuild download step: ${this.moduleName}`);
       let success = false;
-      const shimExt = process.env.ELECTRON_REBUILD_TESTS ? 'ts' : 'js';
-      const executable = process.env.ELECTRON_REBUILD_TESTS ? path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node') : process.execPath;
       try {
-        await spawn(
-          executable,
-          [
-            path.resolve(__dirname, `prebuild-shim.${shimExt}`),
-            prebuildInstallPath,
-            `--arch=${this.rebuilder.arch}`,
-            `--platform=${process.platform}`,
-            '--runtime=electron',
-            `--target=${this.rebuilder.electronVersion}`,
-            `--tag-prefix=${this.rebuilder.prebuildTagPrefix}`
-          ],
-          {
-            cwd: this.modulePath,
-          }
-        );
+        await this.runPrebuildInstall(prebuildInstallPath);
         success = true;
       } catch (err) {
         d('failed to use prebuild-install:', err);
@@ -234,6 +218,27 @@ export class ModuleRebuilder {
       await fs.ensureDir(abiPath);
       await fs.copy(nodePath, path.resolve(abiPath, `${this.moduleName}.node`));
     }
+  }
+
+  async runPrebuildInstall(prebuildInstallPath: string): Promise<void> {
+    const shimExt = process.env.ELECTRON_REBUILD_TESTS ? 'ts' : 'js';
+    const executable = process.env.ELECTRON_REBUILD_TESTS ? path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node') : process.execPath;
+
+    await spawn(
+      executable,
+      [
+        path.resolve(__dirname, `prebuild-shim.${shimExt}`),
+        prebuildInstallPath,
+        `--arch=${this.rebuilder.arch}`,
+        `--platform=${process.platform}`,
+        '--runtime=electron',
+        `--target=${this.rebuilder.electronVersion}`,
+        `--tag-prefix=${this.rebuilder.prebuildTagPrefix}`
+      ],
+      {
+        cwd: this.modulePath,
+      }
+    );
   }
 
   async writeMetadata(): Promise<void> {

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -1,0 +1,268 @@
+import * as debug from 'debug';
+import * as detectLibc from 'detect-libc';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { cacheModuleState } from './cache';
+import { readPackageJson } from './read-package-json';
+import { Rebuilder } from './rebuild';
+import { spawn } from '@malept/cross-spawn-promise';
+
+const d = debug('electron-windows-installer:module-rebuilder');
+
+const locateBinary = async (basePath: string, suffix: string): Promise<string | null> => {
+  let testPath = basePath;
+  for (let upDir = 0; upDir <= 20; upDir ++) {
+    const checkPath = path.resolve(testPath, suffix);
+    if (await fs.pathExists(checkPath)) {
+      return checkPath;
+    }
+    testPath = path.resolve(testPath, '..');
+  }
+  return null;
+};
+
+let nodeGypPath: string | null | undefined;
+
+async function locateNodeGyp(): Promise<string | null> {
+  if (nodeGypPath === undefined) {
+    nodeGypPath = await locateBinary(__dirname, `node_modules/.bin/node-gyp${process.platform === 'win32' ? '.cmd' : ''}`);
+  }
+
+  return nodeGypPath;
+};
+
+const locatePrebuild = async (modulePath: string): Promise<string | null> => {
+  return await locateBinary(modulePath, 'node_modules/prebuild-install/bin.js');
+};
+
+export enum BuildType {
+  Debug = 'Debug',
+  Release = 'Release',
+}
+
+export class ModuleRebuilder {
+  private modulePath: string;
+  private packageJSON: object;
+  private rebuilder: Rebuilder;
+
+  constructor(rebuilder: Rebuilder, modulePath: string) {
+    this.modulePath = modulePath;
+    this.rebuilder = rebuilder;
+  }
+
+  get buildType(): BuildType {
+    return this.rebuilder.debug ? BuildType.Debug : BuildType.Release;
+  }
+
+  get metaPath(): string {
+    return path.resolve(this.modulePath, 'build', this.buildType, '.forge-meta');
+  }
+
+  get metaData(): string {
+    return `${this.rebuilder.arch}--${this.rebuilder.ABI}`;
+  }
+
+  get moduleName(): string {
+    return path.basename(this.modulePath);
+  }
+
+  get nodeGypEnv() {
+    /* eslint-disable @typescript-eslint/camelcase */
+    return {
+      ...process.env,
+      USERPROFILE: path.resolve(os.homedir(), '.electron-gyp'),
+      npm_config_disturl: 'https://www.electronjs.org/headers',
+      npm_config_runtime: 'electron',
+      npm_config_arch: this.rebuilder.arch,
+      npm_config_target_arch: this.rebuilder.arch,
+      npm_config_build_from_source: 'true',
+      npm_config_debug: this.rebuilder.debug ? 'true' : '',
+      npm_config_devdir: path.resolve(os.homedir(), '.electron-gyp'),
+    }
+    /* eslint-enable @typescript-eslint/camelcase */
+  }
+
+  async alreadyBuiltByRebuild(): Promise<boolean> {
+    if (await fs.pathExists(this.metaPath)) {
+      const meta = await fs.readFile(this.metaPath, 'utf8');
+      return meta === this.metaData;
+    }
+
+    return false;
+  }
+
+  async buildNodeGypArgs() {
+    const args = [
+      'rebuild',
+      `--target=${this.rebuilder.electronVersion}`,
+      `--arch=${this.rebuilder.arch}`,
+      `--dist-url=${this.rebuilder.headerURL}`,
+      '--build-from-source',
+    ];
+
+    if (this.rebuilder.debug) {
+      args.push('--debug');
+    }
+
+    args.push(...(await this.buildNodeGypArgsFromBinaryField()));
+
+    if (process.env.GYP_MSVS_VERSION) {
+      args.push(`--msvs_version=${process.env.GYP_MSVS_VERSION}`);
+    }
+
+    return args;
+  }
+
+  async buildNodeGypArgsFromBinaryField(): Promise<string[]> {
+    const binary = await this.packageJSONField('binary', {}) as Record<string, string>;
+    const flags = await Promise.all(Object.entries(binary).map(async ([binaryKey, binaryValue]) => {
+      if (binaryKey === 'napi_versions') {
+        return;
+      }
+
+      let value = binaryValue
+
+      if (binaryKey === 'module_path') {
+        value = path.resolve(this.modulePath, value);
+      }
+
+      value = value.replace('{configuration}', this.buildType)
+        .replace('{node_abi}', `electron-v${this.rebuilder.electronVersion.split('.').slice(0, 2).join('.')}`)
+        .replace('{platform}', process.platform)
+        .replace('{arch}', this.rebuilder.arch)
+        .replace('{version}', await this.packageJSONField('version'))
+        .replace('{libc}', detectLibc.family || 'unknown');
+
+      for (const [replaceKey, replaceValue] of Object.entries(binary)) {
+        value = value.replace(`{${replaceKey}}`, replaceValue);
+      }
+
+      return `--${binaryKey}=${value}`;
+    }))
+
+    return flags.filter(value => value) as string[];
+  }
+
+  async cacheModuleState(cacheKey: string) {
+    if (this.rebuilder.useCache) {
+      await cacheModuleState(this.modulePath, this.rebuilder.cachePath, cacheKey);
+    }
+  }
+
+  async isPrebuildNativeModule(): Promise<boolean> {
+    const dependencies = await this.packageJSONField('dependencies', {});
+    return !!dependencies['prebuild-install']
+  }
+
+  async packageJSONField(key: string, defaultValue?: any): Promise<any> {
+    if (!this.packageJSON) {
+      this.packageJSON = await readPackageJson(this.modulePath);
+    }
+
+    return this.packageJSON[key] || defaultValue;
+  }
+
+  /**
+   * Whether a prebuild-based native module exists.
+   */
+  async prebuildNativeModuleExists(): Promise<boolean> {
+    return fs.pathExists(path.resolve(this.modulePath, 'prebuilds', `${process.platform}-${this.rebuilder.arch}`, `electron-${this.rebuilder.ABI}.node`))
+  }
+
+  async rebuildNodeGypModule(cacheKey: string): Promise<void> {
+    const nodeGypPath = await locateNodeGyp();
+    if (!nodeGypPath) {
+      throw new Error('Could not locate node-gyp');
+    }
+
+    if (this.modulePath.includes(' ')) {
+      console.error('Attempting to build a module with a space in the path');
+      console.error('See https://github.com/nodejs/node-gyp/issues/65#issuecomment-368820565 for reasons why this may not work');
+      // FIXME: Re-enable the throw when more research has been done
+      // throw new Error(`node-gyp does not support building modules with spaces in their path, tried to build: ${modulePath}`);
+    }
+
+    const nodeGypArgs = await this.buildNodeGypArgs();
+
+    d('rebuilding', this.moduleName, 'with args', nodeGypArgs);
+    await spawn(nodeGypPath, nodeGypArgs, {
+      cwd: this.modulePath,
+      env: this.nodeGypEnv,
+    });
+
+    d('built:', this.moduleName);
+    await this.writeMetadata();
+    await this.replaceExistingNativeModule();
+    await this.cacheModuleState(cacheKey)
+  }
+
+  async rebuildPrebuildModule(cacheKey: string): Promise<boolean> {
+    if (!(await this.rebuildPrebuildModule())) {
+      return false;
+    }
+
+    d(`assuming is prebuild powered: ${this.moduleName}`);
+    const prebuildInstallPath = await locatePrebuild(this.modulePath);
+    if (prebuildInstallPath) {
+      d(`triggering prebuild download step: ${this.moduleName}`);
+      let success = false;
+      const shimExt = process.env.ELECTRON_REBUILD_TESTS ? 'ts' : 'js';
+      const executable = process.env.ELECTRON_REBUILD_TESTS ? path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node') : process.execPath;
+      try {
+        await spawn(
+          executable,
+          [
+            path.resolve(__dirname, `prebuild-shim.${shimExt}`),
+            prebuildInstallPath,
+            `--arch=${this.rebuilder.arch}`,
+            `--platform=${process.platform}`,
+            '--runtime=electron',
+            `--target=${this.rebuilder.electronVersion}`,
+            `--tag-prefix=${this.rebuilder.prebuildTagPrefix}`
+          ],
+          {
+            cwd: this.modulePath,
+          }
+        );
+        success = true;
+      } catch (err) {
+        d('failed to use prebuild-install:', err);
+      }
+      if (success) {
+        d('built:', this.moduleName);
+        await this.writeMetadata();
+        await this.cacheModuleState(cacheKey);
+        return true;
+      }
+    } else {
+      d(`could not find prebuild-install relative to: ${this.modulePath}`);
+    }
+
+    return false;
+  }
+
+  async replaceExistingNativeModule() {
+    const buildLocation = path.resolve(this.modulePath, 'build', this.buildType);
+
+    d('searching for .node file', buildLocation);
+    const buildLocationFiles = await fs.readdir(buildLocation);
+    d('testing files', buildLocationFiles);
+
+    const nodeFile = buildLocationFiles.find((file) => file !== '.node' && file.endsWith('.node'));
+    const nodePath = nodeFile ? path.resolve(buildLocation, nodeFile) : undefined;
+
+    if (nodePath && await fs.pathExists(nodePath)) {
+      d('found .node file', nodePath);
+      const abiPath = path.resolve(this.modulePath, `bin/${process.platform}-${this.rebuilder.arch}-${this.rebuilder.ABI}`);
+      d('copying to prebuilt place:', abiPath);
+      await fs.ensureDir(abiPath);
+      await fs.copy(nodePath, path.resolve(abiPath, `${this.moduleName}.node`));
+    }
+  }
+
+  async writeMetadata() {
+    await fs.ensureDir(path.dirname(this.metaPath));
+    await fs.writeFile(this.metaPath, this.metaData);
+  }
+}

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { readPackageJson } from './read-package-json';
-import { lookupModuleState, cacheModuleState } from './cache';
+import { lookupModuleState } from './cache';
 import { searchForModule, searchForNodeModules } from './search-module';
 
 export type ModuleType = 'prod' | 'dev' | 'optional';
@@ -227,6 +227,7 @@ export class Rebuilder {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { ModuleRebuilder } = require('./module-rebuilder');
     const moduleRebuilder = new ModuleRebuilder(this, modulePath);
 

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -240,7 +240,7 @@ export class Rebuilder {
       return;
     }
 
-    if (moduleRebuilder.prebuildNativeModuleExists(modulePath)) {
+    if (await moduleRebuilder.prebuildNativeModuleExists(modulePath)) {
       d(`skipping: ${path.basename(modulePath)} as it was prebuilt`);
       return;
     }

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -1,12 +1,10 @@
 import * as crypto from 'crypto';
 import * as debug from 'debug';
-import * as detectLibc from 'detect-libc';
 import { EventEmitter } from 'events';
 import * as fs from 'fs-extra';
 import * as nodeAbi from 'node-abi';
 import * as os from 'os';
 import * as path from 'path';
-import { spawn } from '@malept/cross-spawn-promise';
 
 import { readPackageJson } from './read-package-json';
 import { lookupModuleState, cacheModuleState } from './cache';
@@ -45,27 +43,7 @@ const defaultTypes: ModuleType[] = ['prod', 'optional'];
 // Update this number if you change the caching logic to ensure no bad cache hits
 const ELECTRON_REBUILD_CACHE_ID = 1;
 
-const locateBinary = async (basePath: string, suffix: string): Promise<string | null> => {
-  let testPath = basePath;
-  for (let upDir = 0; upDir <= 20; upDir ++) {
-    const checkPath = path.resolve(testPath, suffix);
-    if (await fs.pathExists(checkPath)) {
-      return checkPath;
-    }
-    testPath = path.resolve(testPath, '..');
-  }
-  return null;
-};
-
-const locateNodeGyp = async (): Promise<string | null> => {
-  return await locateBinary(__dirname, `node_modules/.bin/node-gyp${process.platform === 'win32' ? '.cmd' : ''}`);
-};
-
-const locatePrebuild = async (modulePath: string): Promise<string | null> => {
-  return await locateBinary(modulePath, 'node_modules/prebuild-install/bin.js');
-};
-
-class Rebuilder {
+export class Rebuilder {
   ABI: string;
   nodeGypPath: string;
   prodDeps: Set<string>;
@@ -249,30 +227,19 @@ class Rebuilder {
       return;
     }
 
-    const nodeGypPath = await locateNodeGyp();
-    if (!nodeGypPath) {
-      throw new Error('Could not locate node-gyp');
-    }
-
-    const buildType = this.debug ? 'Debug' : 'Release';
-
-    const metaPath = path.resolve(modulePath, 'build', buildType, '.forge-meta');
-    const metaData = `${this.arch}--${this.ABI}`;
+    const { ModuleRebuilder } = require('./module-rebuilder');
+    const moduleRebuilder = new ModuleRebuilder(this, modulePath);
 
     this.lifecycle.emit('module-found', path.basename(modulePath));
 
-    if (!this.force && await fs.pathExists(metaPath)) {
-      const meta = await fs.readFile(metaPath, 'utf8');
-      if (meta === metaData) {
-        d(`skipping: ${path.basename(modulePath)} as it is already built`);
-        this.lifecycle.emit('module-done');
-        this.lifecycle.emit('module-skip');
-        return;
-      }
+    if (!this.force && await moduleRebuilder.alreadyBuiltByRebuild()) {
+      d(`skipping: ${path.basename(modulePath)} as it is already built`);
+      this.lifecycle.emit('module-done');
+      this.lifecycle.emit('module-skip');
+      return;
     }
 
-    // prebuild already exists
-    if (await fs.pathExists(path.resolve(modulePath, 'prebuilds', `${process.platform}-${this.arch}`, `electron-${this.ABI}.node`))) {
+    if (moduleRebuilder.prebuildNativeModuleExists(modulePath)) {
       d(`skipping: ${path.basename(modulePath)} as it was prebuilt`);
       return;
     }
@@ -291,140 +258,11 @@ class Rebuilder {
       }
     }
 
-    const modulePackageJson = await readPackageJson(modulePath);
-
-    if ((modulePackageJson.dependencies || {})['prebuild-install']) {
-      d(`assuming is prebuild powered: ${path.basename(modulePath)}`);
-      const prebuildInstallPath = await locatePrebuild(modulePath);
-      if (prebuildInstallPath) {
-        d(`triggering prebuild download step: ${path.basename(modulePath)}`);
-        let success = false;
-        const shimExt = process.env.ELECTRON_REBUILD_TESTS ? 'ts' : 'js';
-        const executable = process.env.ELECTRON_REBUILD_TESTS ? path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node') : process.execPath;
-        try {
-          await spawn(
-            executable,
-            [
-              path.resolve(__dirname, `prebuild-shim.${shimExt}`),
-              prebuildInstallPath,
-              `--arch=${this.arch}`,
-              `--platform=${process.platform}`,
-              '--runtime=electron',
-              `--target=${this.electronVersion}`,
-              `--tag-prefix=${this.prebuildTagPrefix}`
-            ],
-            {
-              cwd: modulePath,
-            }
-          );
-          success = true;
-        } catch (err) {
-          d('failed to use prebuild-install:', err);
-        }
-        if (success) {
-          d('built:', path.basename(modulePath));
-          await fs.mkdirs(path.dirname(metaPath));
-          await fs.writeFile(metaPath, metaData);
-          if (this.useCache) {
-            await cacheModuleState(modulePath, this.cachePath, cacheKey);
-          }
-          this.lifecycle.emit('module-done');
-          return;
-        }
-      } else {
-        d(`could not find prebuild-install relative to: ${modulePath}`);
-      }
+    if (await moduleRebuilder.rebuildPrebuildModule(cacheKey)) {
+      this.lifecycle.emit('module-done');
+      return;
     }
-    if (modulePath.indexOf(' ') !== -1) {
-      console.error('Attempting to build a module with a space in the path');
-      console.error('See https://github.com/nodejs/node-gyp/issues/65#issuecomment-368820565 for reasons why this may not work');
-      // FIXME: Re-enable the throw when more research has been done
-      // throw new Error(`node-gyp does not support building modules with spaces in their path, tried to build: ${modulePath}`);
-    }
-    d('rebuilding:', path.basename(modulePath));
-    const rebuildArgs = [
-      'rebuild',
-      `--target=${this.electronVersion}`,
-      `--arch=${this.arch}`,
-      `--dist-url=${this.headerURL}`,
-      '--build-from-source',
-    ];
-
-    if (this.debug) {
-      rebuildArgs.push('--debug');
-    }
-
-    for (const binaryKey of Object.keys(modulePackageJson.binary || {})) {
-      if (binaryKey === 'napi_versions') {
-        continue;
-      }
-
-      let value = modulePackageJson.binary[binaryKey];
-
-      if (binaryKey === 'module_path') {
-        value = path.resolve(modulePath, value);
-      }
-
-      value = value.replace('{configuration}', buildType)
-        .replace('{node_abi}', `electron-v${this.electronVersion.split('.').slice(0, 2).join('.')}`)
-        .replace('{platform}', process.platform)
-        .replace('{arch}', this.arch)
-        .replace('{version}', modulePackageJson.version)
-        .replace('{libc}', detectLibc.family || 'unknown');
-
-      for (const binaryReplaceKey of Object.keys(modulePackageJson.binary)) {
-        value = value.replace(`{${binaryReplaceKey}}`, modulePackageJson.binary[binaryReplaceKey]);
-      }
-
-      rebuildArgs.push(`--${binaryKey}=${value}`);
-    }
-
-    if (process.env.GYP_MSVS_VERSION) {
-      rebuildArgs.push(`--msvs_version=${process.env.GYP_MSVS_VERSION}`);
-    }
-
-    d('rebuilding', path.basename(modulePath), 'with args', rebuildArgs);
-    await spawn(nodeGypPath, rebuildArgs, {
-      cwd: modulePath,
-      /* eslint-disable @typescript-eslint/camelcase */
-      env: Object.assign({}, process.env, {
-        USERPROFILE: path.resolve(os.homedir(), '.electron-gyp'),
-        npm_config_disturl: 'https://electronjs.org/headers',
-        npm_config_runtime: 'electron',
-        npm_config_arch: this.arch,
-        npm_config_target_arch: this.arch,
-        npm_config_build_from_source: 'true',
-        npm_config_debug: this.debug ? 'true' : '',
-        npm_config_devdir: path.resolve(os.homedir(), '.electron-gyp'),
-      }),
-      /* eslint-enable @typescript-eslint/camelcase */
-    });
-
-    d('built:', path.basename(modulePath));
-    await fs.mkdirs(path.dirname(metaPath));
-    await fs.writeFile(metaPath, metaData);
-
-    const moduleName = path.basename(modulePath);
-    const buildLocation = 'build/' + buildType;
-
-    d('searching for .node file', path.resolve(modulePath, buildLocation));
-    d('testing files', (await fs.readdir(path.resolve(modulePath, buildLocation))));
-
-    const nodeFile = (await fs.readdir(path.resolve(modulePath, buildLocation)))
-      .find((file) => file !== '.node' && file.endsWith('.node'));
-    const nodePath = nodeFile ? path.resolve(modulePath, buildLocation, nodeFile) : undefined;
-
-    const abiPath = path.resolve(modulePath, `bin/${process.platform}-${this.arch}-${this.ABI}`);
-    if (nodePath && await fs.pathExists(nodePath)) {
-      d('found .node file', nodePath);
-      d('copying to prebuilt place:', abiPath);
-      await fs.mkdirs(abiPath);
-      await fs.copy(nodePath, path.resolve(abiPath, `${moduleName}.node`));
-    }
-
-    if (this.useCache) {
-      await cacheModuleState(modulePath, this.cachePath, cacheKey);
-    }
+    await moduleRebuilder.rebuildNodeGypModule(cacheKey);
     this.lifecycle.emit('module-done');
   }
 

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -1,0 +1,1 @@
+declare module 'node-gyp';


### PR DESCRIPTION
Turns out the module uses command line arguments :cry: but it's still better than using `spawn`.

Also extracts the actual module rebuilding to its own class.