### PR TITLE
Update node-abi to 2.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3857,9 +3857,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
-      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.17.0.tgz",
+      "integrity": "sha512-dFRAA0ACk/aBo0TIXQMEWMLUTyWYYT8OBYIzLmEUrQTElGRjxDCvyBZIsDL0QA7QCaj9PrawhOmTEdsuLY4uOQ==",
       "requires": {
         "semver": "^5.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.1.1",
     "detect-libc": "^1.0.3",
     "fs-extra": "^8.1.0",
-    "node-abi": "^2.11.0",
+    "node-abi": "^2.17.0",
     "node-gyp": "^6.0.1",
     "ora": "^3.4.0",
     "spawn-rx": "^3.0.0",


### PR DESCRIPTION
This would allow me and others to use electron-rebuild with electron 9.0.0

Unless I'm misunderstanding? Let me know :slightly_smiling_face:.