### PR TITLE
fix: allow "only" modules to match fully qualified scoped module names

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -452,7 +452,12 @@ class Rebuilder {
       }
       this.realModulePaths.add(realPath);
 
-      if (this.prodDeps[`${prefix}${modulePath}`] && (!this.onlyModules || this.onlyModules.includes(modulePath))) {
+      if (
+        this.prodDeps[`${prefix}${modulePath}`] &&
+        (!this.onlyModules ||
+          this.onlyModules.includes(modulePath) ||
+          this.onlyModules.includes(`${prefix}${modulePath}`))
+      ) {
         this.rebuilds.push(() => this.rebuildModuleAt(realPath));
       }
 

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -144,6 +144,34 @@ describe('rebuilder', () => {
       expect(built).to.equal(1);
     });
 
+    it('should rebuild only specified modules with prefixes', async () => {
+      const rebuilder = rebuild({
+        buildPath: testModulePath,
+        electronVersion: '5.0.13',
+        arch: process.arch,
+        onlyModules: ['@nlv8/signun'],
+        force: true
+      });
+      let built = 0;
+      rebuilder.lifecycle.on('module-done', () => built++);
+      await rebuilder;
+      expect(built).to.equal(1);
+    });
+
+    it('should rebuild only specified modules missing prefixes', async () => {
+      const rebuilder = rebuild({
+        buildPath: testModulePath,
+        electronVersion: '5.0.13',
+        arch: process.arch,
+        onlyModules: ['signun'],
+        force: true
+      });
+      let built = 0;
+      rebuilder.lifecycle.on('module-done', () => built++);
+      await rebuilder;
+      expect(built).to.equal(1);
+    });
+
     it('should rebuild multiple specified modules via --only option', async () => {
       const rebuilder = rebuild({
         buildPath: testModulePath,


### PR DESCRIPTION
At the moment, modules specified with `-o` or `--only` can only match if you don't supply the prefix. This change allows you to specify a prefixed version of the module but doesn't break the current behavior.