### PR TITLE
docs: Clarify that -w is only respected when modules are a subset of those matching current types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Options:
   -m, --module-dir             The path to the app directory to rebuild
   -w, --which-module           A specific module to build, or comma separated
                                list of modules. Modules will only be rebuilt if they 
-                               also match the types of dependencies being rebuilt.
+                               also match the types of dependencies being rebuilt
+                               (see --types).
   -e, --electron-prebuilt-dir  The path to electron-prebuilt
   -d, --dist-url               Custom header tarball URL
   -t, --types                  The types of dependencies to rebuild.  Comma

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Options:
                                other than your system's
   -m, --module-dir             The path to the app directory to rebuild
   -w, --which-module           A specific module to build, or comma separated
-                               list of modules
+                               list of modules. Modules will only be rebuilt if they 
+                               also match the types of dependencies being rebuilt.
   -e, --electron-prebuilt-dir  The path to electron-prebuilt
   -d, --dist-url               Custom header tarball URL
   -t, --types                  The types of dependencies to rebuild.  Comma

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ const yargs = argParser
   .alias('a', 'arch')
   .describe('m', 'The path to the node_modules directory to rebuild')
   .alias('m', 'module-dir')
-  .describe('w', ' A specific module to build, or comma separated list of modules. Modules will only be rebuilt if they also match the types of dependencies being rebuilt.')
+  .describe('w', 'A specific module to build, or comma separated list of modules. Modules will only be rebuilt if they also match the types of dependencies being rebuilt (see --types).')
   .alias('w', 'which-module')
   .describe('o', 'Only build specified module, or comma separated list of modules. All others are ignored.')
   .alias('o', 'only')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ const yargs = argParser
   .alias('a', 'arch')
   .describe('m', 'The path to the node_modules directory to rebuild')
   .alias('m', 'module-dir')
-  .describe('w', 'A specific module to build, or comma separated list of modules')
+  .describe('w', ' A specific module to build, or comma separated list of modules. Modules will only be rebuilt if they also match the types of dependencies being rebuilt.')
   .alias('w', 'which-module')
   .describe('o', 'Only build specified module, or comma separated list of modules. All others are ignored.')
   .alias('o', 'only')


### PR DESCRIPTION
This change adds clarification to the docs explaining that modules defined with `-w` or `--which-module` must match those defined in types. In the code, this is enforced here

https://github.com/electron/electron-rebuild/blob/fac334634e856d5438fad74d34c91a41e30a43fa/src/rebuild.ts#L154-L165