### PR TITLE
docs: update node version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run rebuild
 
 ### What are the requirements?
 
-Node v6.0.0 or higher is required. Building the native modules from source uses
+Node v10.0.0 or higher is required. Building the native modules from source uses
 [`node-gyp`](https://github.com/nodejs/node-gyp#installation), refer to the link for its
 installation/runtime requirements.
 


### PR DESCRIPTION
[ci skip]
electron-rebuild 2.0.0 depends on node >=10.0.0