### PR TITLE
refactor: replace spawn-rx with @malept/cross-spawn-promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,52 @@
         }
       }
     },
+    "@malept/cross-spawn-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.0.tgz",
+      "integrity": "sha512-GeIK5rfU1Yd7BZJQPTGZMMmcZy5nhRToPXZcjaDwQDRSewdhp648GT2E4dh+L7+Io7AOW6WQ+GR44QSzja4qxg==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -3598,11 +3644,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -8656,14 +8697,6 @@
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
-    "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -9047,31 +9080,6 @@
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
       "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
       "dev": true
-    },
-    "spawn-rx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-3.0.0.tgz",
-      "integrity": "sha512-dw4Ryg/KMNfkKa5ezAR5aZe9wNwPdKlnHEXtHOjVnyEDSPQyOpIPPRtcIiu7127SmtHhaCjw21yC43HliW0iIg==",
-      "requires": {
-        "debug": "^2.5.1",
-        "lodash.assign": "^4.2.0",
-        "rxjs": "^6.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -9562,7 +9570,8 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
+    "@malept/cross-spawn-promise": "^1.1.0",
     "colors": "^1.3.3",
     "debug": "^4.1.1",
     "detect-libc": "^1.0.3",
@@ -39,7 +40,6 @@
     "node-abi": "^2.19.0",
     "node-gyp": "^7.1.0",
     "ora": "^5.0.0",
-    "spawn-rx": "^3.0.0",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -1,4 +1,3 @@
-import { spawnPromise } from 'spawn-rx';
 import * as crypto from 'crypto';
 import * as debug from 'debug';
 import * as detectLibc from 'detect-libc';
@@ -7,6 +6,8 @@ import * as fs from 'fs-extra';
 import * as nodeAbi from 'node-abi';
 import * as os from 'os';
 import * as path from 'path';
+import { spawn } from '@malept/cross-spawn-promise';
+
 import { readPackageJson } from './read-package-json';
 import { lookupModuleState, cacheModuleState } from './cache';
 import { searchForModule, searchForNodeModules } from './search-module';
@@ -302,7 +303,7 @@ class Rebuilder {
         const shimExt = process.env.ELECTRON_REBUILD_TESTS ? 'ts' : 'js';
         const executable = process.env.ELECTRON_REBUILD_TESTS ? path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node') : process.execPath;
         try {
-          await spawnPromise(
+          await spawn(
             executable,
             [
               path.resolve(__dirname, `prebuild-shim.${shimExt}`),
@@ -386,7 +387,7 @@ class Rebuilder {
     d('rebuilding', path.basename(modulePath), 'with args', rebuildArgs);
     const devDir = path.resolve(os.homedir(), '.electron-gyp');
     await fs.mkdirp(devDir)
-    await spawnPromise(nodeGypPath, rebuildArgs, {
+    await spawn(nodeGypPath, rebuildArgs, {
       cwd: modulePath,
       env: Object.assign({}, process.env, {
         USERPROFILE: devDir,

--- a/test/electron-locator.ts
+++ b/test/electron-locator.ts
@@ -1,12 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { expect } from 'chai';
-import { spawnPromise } from 'spawn-rx';
+import { spawn } from '@malept/cross-spawn-promise';
 
 import { locateElectronModule } from '../src/electron-locator';
 
 function packageCommand(command: string, packageName: string): Promise<string> {
-  return spawnPromise('npm', [command, '--no-save', packageName], {
+  return spawn('npm', [command, '--no-save', packageName], {
     cwd: path.resolve(__dirname, '..'),
     stdio: 'ignore',
   });

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { spawnPromise } from 'spawn-rx';
+import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { rebuild } from '../src/rebuild';
@@ -16,7 +16,7 @@ describe.skip('rebuild for yarn workspace', function() {
       await fs.remove(testModulePath);
       await fs.copy(path.resolve(__dirname, 'fixture/workspace-test'), testModulePath);
 
-      await spawnPromise('yarn', [], {
+      await spawn('yarn', [], {
         cwd: testModulePath,
         stdio: 'ignore'
       });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { spawnPromise } from 'spawn-rx';
+import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { rebuild, RebuildOptions } from '../src/rebuild';
@@ -18,7 +18,7 @@ describe('rebuilder', () => {
       path.resolve(__dirname, '../test/fixture/native-app1/package.json'),
       path.resolve(testModulePath, 'package.json')
     );
-    await spawnPromise('npm', ['install'], {
+    await spawn('npm', ['install'], {
       cwd: testModulePath,
       stdio: 'ignore',
     });


### PR DESCRIPTION
Effectively required to make it easier to debug issues with running commands (e.g., #382, or the Node 14 errors in CI). This module is also used in other modules across the Electron tool ecosystem.