### PR TITLE
build: reduce released module size

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "bin": {
     "electron-rebuild": "lib/src/cli.js"
   },
+  "files": [
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/electron/electron-rebuild"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-      "ecmaVersion": 8,
+      "ecmaVersion": "2018",
       "sourceType": "module"
     },
     "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "pretty": true,
-    "target": "ES2016",
+    "target": "ES2018",
     "outDir": "lib"
   },
   "formatCodeOptions": {


### PR DESCRIPTION
* only package files from the `lib` folder
* Emit ES2018 (Node 10) JavaScript from `tsc`