### PR TITLE
fix: run node-gyp rebuild correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ jobs:
     executor:
       name: win/vs2019
       shell: bash.exe
+    environment:
+      GYP_MSVS_VERSION: '2019'
     <<: *steps-test
 
   release:

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -93,8 +93,8 @@ export class ModuleRebuilder {
 
     args.push(...(await this.buildNodeGypArgsFromBinaryField()));
 
-    if (process.env.GYP_MSVS_VERSION) {
-      args.push(`--msvs_version=${process.env.GYP_MSVS_VERSION}`);
+    if (this.rebuilder.msvsVersion) {
+      args.push(`--msvs_version=${this.rebuilder.msvsVersion}`);
     }
 
     return args;

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -171,9 +171,12 @@ export class ModuleRebuilder {
 
     const nodeGyp = NodeGyp();
     nodeGyp.parseArgv(nodeGypArgs);
-    const rebuildArgs = nodeGyp.todo[0].args;
-    d('rebuilding', this.moduleName, 'with args', rebuildArgs);
-    await promisify(nodeGyp.commands.rebuild)(rebuildArgs);
+    let command = nodeGyp.todo.shift();
+    d('rebuilding', this.moduleName, 'with args', command.args);
+    while (command) {
+      await promisify(nodeGyp.commands[command.name])(command.args);
+      command = nodeGyp.todo.shift();
+    }
 
     d('built:', this.moduleName);
     await this.writeMetadata();

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -168,11 +168,11 @@ export class ModuleRebuilder {
     }
 
     const nodeGypArgs = await this.buildNodeGypArgs();
+    d('rebuilding', this.moduleName, 'with args', nodeGypArgs);
 
     const nodeGyp = NodeGyp();
     nodeGyp.parseArgv(nodeGypArgs);
     let command = nodeGyp.todo.shift();
-    d('rebuilding', this.moduleName, 'with args', command.args);
     const originalWorkingDir = process.cwd();
     try {
       process.chdir(this.modulePath);

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -67,6 +67,7 @@ export class Rebuilder {
   public cachePath: string;
   public prebuildTagPrefix: string;
   public projectRootPath?: string;
+  public msvsVersion?: string;
 
   constructor(options: RebuilderOptions) {
     this.lifecycle = options.lifecycle;
@@ -83,6 +84,7 @@ export class Rebuilder {
     this.useCache = options.useCache || false;
     this.cachePath = options.cachePath || path.resolve(os.homedir(), '.electron-rebuild-cache');
     this.prebuildTagPrefix = options.prebuildTagPrefix || 'v';
+    this.msvsVersion = process.env.GYP_MSVS_VERSION;
 
     if (this.useCache && this.force) {
       console.warn('[WARNING]: Electron Rebuild has force enabled and cache enabled, force take precedence and the cache will not be used.');

--- a/test/helpers/checksum.ts
+++ b/test/helpers/checksum.ts
@@ -1,0 +1,21 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs-extra';
+import { promisify } from 'util';
+import * as stream from 'stream';
+
+const pipeline = promisify(stream.pipeline);
+
+export async function determineChecksum(filename: string): Promise<string> {
+  let calculated = '';
+  const file = fs.createReadStream(filename, { encoding: 'binary' });
+  const hasher = crypto.createHash('sha256', { defaultEncoding: 'binary' });
+  hasher.on('readable', () => {
+    const data = hasher.read();
+    if (data) {
+      calculated = data.toString('hex');
+    }
+  });
+  await pipeline(file, hasher);
+
+  return calculated;
+}

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -13,6 +13,7 @@ const testElectronVersion = getExactElectronVersionSync();
 describe('rebuild for yarn workspace', function() {
   this.timeout(2 * 60 * 1000);
   const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
+  const msvs_version: string | undefined = process.env.GYP_MSVS_VERSION;
 
   describe('core behavior', () => {
     before(async () => {
@@ -20,6 +21,9 @@ describe('rebuild for yarn workspace', function() {
       await fs.copy(path.resolve(__dirname, 'fixture/workspace-test'), testModulePath);
 
       await spawn('yarn', [], { cwd: testModulePath });
+      if (msvs_version) {
+        process.env.GYP_MSVS_VERSION = msvs_version;
+      }
 
       const projectRootPath = await getProjectRootPath(path.join(testModulePath, 'workspace-test', 'child-workspace'));
 
@@ -41,6 +45,9 @@ describe('rebuild for yarn workspace', function() {
 
     after(async () => {
       await fs.remove(testModulePath);
+      if (msvs_version) {
+        process.env.GYP_MSVS_VERSION = msvs_version;
+      }
     });
   });
 });


### PR DESCRIPTION
It should have iterated through all of the node-gyp commands since `node-gyp rebuild` pushes `clean`, `configure`, and `build` commands to the `todo` list. Also:

* ensures that the module path is the current working directory when it's running
* adds a regression test

Fixes #404 