### PR TITLE
fix: only call node-abi when there's a module to rebuild

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -47,7 +47,7 @@ const defaultTypes: ModuleType[] = ['prod', 'optional'];
 const ELECTRON_REBUILD_CACHE_ID = 1;
 
 export class Rebuilder {
-  ABIVersion: string | undefined;
+  private ABIVersion: string | undefined;
   nodeGypPath: string;
   prodDeps: Set<string>;
   rebuilds: (() => Promise<void>)[];

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -47,7 +47,7 @@ const defaultTypes: ModuleType[] = ['prod', 'optional'];
 const ELECTRON_REBUILD_CACHE_ID = 1;
 
 export class Rebuilder {
-  ABI: string;
+  ABIVersion: string | undefined;
   nodeGypPath: string;
   prodDeps: Set<string>;
   rebuilds: (() => Promise<void>)[];
@@ -109,11 +109,19 @@ export class Rebuilder {
       throw new Error(`Expected a string version for electron version, got a "${typeof this.electronVersion}"`);
     }
 
-    this.ABI = options.forceABI || nodeAbi.getAbi(this.electronVersion, 'electron');
+    this.ABIVersion = options.forceABI?.toString();
     this.prodDeps = this.extraModules.reduce((acc: Set<string>, x: string) => acc.add(x), new Set<string>());
     this.rebuilds = [];
     this.realModulePaths = new Set();
     this.realNodeModulesPaths = new Set();
+  }
+
+  get ABI(): string {
+    if (this.ABIVersion === undefined) {
+      this.ABIVersion = nodeAbi.getAbi(this.electronVersion, 'electron');
+    }
+
+    return this.ABIVersion!;
   }
 
   async rebuild(): Promise<void> {


### PR DESCRIPTION
Electron Forge runs `electron-rebuild` during packaging regardless of whether the Electron app has any native modules (because currently, it doesn't know if it does at that point). This is problematic because that means that `node-abi` is called every time, and if there's a problem with version bumping `node-abi`, they'll incorrectly get the mismatch error.

This pull request should change the rebuilder to only call `node-abi` when `rebuildModuleAt(modulePath)` is called, and cache the result.