### PR TITLE
chore: use @types/node-abi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,6 +1155,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
       "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
     },
+    "@types/node-abi": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node-abi/-/node-abi-2.10.0.tgz",
+      "integrity": "sha512-f2xuMo23SGHNL3v9NEduvaHEGUF+bFeaC6QFHmBYn14dbd4E5JqftXLwKBrGiNsxZafnFHxmNhSC3r2I3JNl3g==",
+      "dev": true
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/lzma-native": "^4.0.0",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.6.0",
+    "@types/node-abi": "^2.10.0",
     "@types/tar": "^4.0.3",
     "@types/yargs": "^15.0.5",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
@@ -80,7 +81,7 @@
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-      "ecmaVersion": "2018",
+      "ecmaVersion": 2018,
       "sourceType": "module"
     },
     "plugins": [

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,2 +1,1 @@
 declare module 'detect-libc';
-declare module 'node-abi';


### PR DESCRIPTION
Removes `node-abi` from `ambient.d.ts` and uses the DefinitelyTyped package.