### PR TITLE
fix: correctly set the devDir path for node-gyp

### DIFF
--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -85,8 +85,7 @@ export class ModuleRebuilder {
       `--target=${this.rebuilder.electronVersion}`,
       `--arch=${this.rebuilder.arch}`,
       `--dist-url=${this.rebuilder.headerURL}`,
-      '--build-from-source',
-      `--devdir="${ELECTRON_GYP_DIR}"`
+      '--build-from-source'
     ];
 
     if (process.env.DEBUG) {
@@ -206,6 +205,7 @@ export class ModuleRebuilder {
 
     const nodeGyp = NodeGyp();
     nodeGyp.parseArgv(nodeGypArgs);
+    nodeGyp.devDir = ELECTRON_GYP_DIR;
     let command = nodeGyp.todo.shift();
     const originalWorkingDir = process.cwd();
     try {

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -96,7 +96,7 @@ describe('rebuilder', () => {
         const modulePath = path.resolve(testModulePath, 'node_modules/ref-napi');
         const fileNames = await fs.readdir(modulePath);
 
-        expect(fileNames).not.contain(testElectronVersion);
+        expect(fileNames).to.not.contain(testElectronVersion);
       });
 
       after(async () => {

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -92,6 +92,13 @@ describe('rebuilder', () => {
         await expectNativeModuleToNotBeRebuilt(testModulePath, 'ffi-napi');
       });
 
+      it('should not download files in the module directory', async () => {
+        const modulePath = path.resolve(testModulePath, 'node_modules/ref-napi');
+        const fileNames = await fs.readdir(modulePath);
+
+        expect(fileNames).not.contain(testElectronVersion);
+      });
+
       after(async () => {
         delete process.env.ELECTRON_REBUILD_TESTS;
         await cleanupTestModule();


### PR DESCRIPTION
I am building my electron project with electron-forge and I have some native dependencies. I noticed that Electron Forge is creating a `11.2.0` folder in my project which I traced down to node-gyp not getting the correct devDir.

The root cause seems to be that the `--devdir` option is parsed inside `bin/node-gyp.js` but electron-rebuild is importing `lib/node-gyp.js` directly. This will fix it by setting the `NodeGyp.devDir` property directly.