### PR TITLE
build: use detect-libc types

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/chai": "^4.2.12",
     "@types/chai-as-promised": "^7.1.3",
     "@types/debug": "^4.1.5",
+    "@types/detect-libc": "^1.0.0",
     "@types/fs-extra": "^9.0.1",
     "@types/lzma-native": "^4.0.0",
     "@types/mocha": "^9.0.0",

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,1 +1,0 @@
-declare module 'detect-libc';

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,6 +749,11 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/detect-libc@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/detect-libc/-/detect-libc-1.0.0.tgz#0a8fcf1242747176684f45fd9c0ce8cffa6803bf"
+  integrity sha512-IIEvhANE4mvK5LjC89FNIaaeuZ/DdM+zXXW1JN1r1lg5djOVCCUo9J3p2yQY2tbna07E+G43TgDNC4w7N4x0Vg==
+
 "@types/fs-extra@^9.0.1":
   version "9.0.12"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.12.tgz#9b8f27973df8a7a3920e8461517ebf8a7d4fdfaf"


### PR DESCRIPTION
Use `@types/detect-libc` instead of the ambient type declaration.