### PR TITLE
rebuild: include prefix when filtering with --only

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -324,7 +324,7 @@ export class Rebuilder {
       }
       this.realModulePaths.add(realPath);
 
-      if (this.prodDeps[`${prefix}${modulePath}`] && (!this.onlyModules || this.onlyModules.includes(modulePath))) {
+      if (this.prodDeps[`${prefix}${modulePath}`] && (!this.onlyModules || this.onlyModules.includes(modulePath) || this.onlyModules.includes(`${prefix}${modulePath}`))) {
         this.rebuilds.push(() => this.rebuildModuleAt(realPath));
       }
 

--- a/test/fixture/native-app2/app/package.json
+++ b/test/fixture/native-app2/app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "native-app",
+  "productName": "Native App",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "electron-forge start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "config": {
+    "forge": "./forge.config.js"
+  },
+  "devDependencies": {
+    "@types/node": "^12.0.10",
+    "@scoped/native-addon": "1.2.3",
+    "ffi-napi": "2.4.5"
+  },
+  "dependencies": {
+    "@newrelic/native-metrics": "5.3.0",
+    "farmhash": "3.2.1",
+    "level": "6.0.0",
+    "native-hello-world": "2.0.0",
+    "ref-napi": "1"
+  }
+}

--- a/test/fixture/native-app2/native-addon/binding.gyp
+++ b/test/fixture/native-app2/native-addon/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "hello",
+      "sources": [ "hello.c" ]
+    }
+  ]
+}

--- a/test/fixture/native-app2/native-addon/hello.c
+++ b/test/fixture/native-app2/native-addon/hello.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <node_api.h>
+
+static napi_value Method(napi_env env, napi_callback_info info) {
+  napi_status status;
+  napi_value world;
+  status = napi_create_string_utf8(env, "world", 5, &world);
+  assert(status == napi_ok);
+  return world;
+}
+
+#define DECLARE_NAPI_METHOD(name, func)                                        \
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_status status;
+  napi_property_descriptor desc = DECLARE_NAPI_METHOD("hello", Method);
+  status = napi_define_properties(env, exports, 1, &desc);
+  assert(status == napi_ok);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/fixture/native-app2/native-addon/hello.js
+++ b/test/fixture/native-app2/native-addon/hello.js
@@ -1,0 +1,2 @@
+const addon = require('./build/Release/hello.node');
+console.log(addon.hello()); // 'world'

--- a/test/fixture/native-app2/native-addon/package.json
+++ b/test/fixture/native-app2/native-addon/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "@scoped/native-addon",
+  "version": "1.2.3",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/test/fixture/native-app2/package.json
+++ b/test/fixture/native-app2/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "workspaces": [
+        "native-addon",
+        "app"
+    ]
+}

--- a/test/helpers/module-setup.ts
+++ b/test/helpers/module-setup.ts
@@ -14,14 +14,22 @@ export function resetMSVSVersion(): void {
   }
 }
 
-export async function resetTestModule(testModulePath: string): Promise<void> {
+export interface ResetTestModuleOptions {
+  packageManager?: string
+  fixturePath?: string
+}
+export async function resetTestModule(testModulePath: string, options: ResetTestModuleOptions = {}): Promise<void> {
+  const {
+    packageManager = 'npm',
+    fixturePath = path.resolve(__dirname, '../../test/fixture/native-app1')
+  } = options;
   await fs.remove(testModulePath);
   await fs.mkdir(testModulePath, { recursive: true });
-  await fs.copyFile(
-    path.resolve(__dirname, '../../test/fixture/native-app1/package.json'),
-    path.resolve(testModulePath, 'package.json')
+  await fs.copy(
+    path.resolve(fixturePath),
+    path.resolve(testModulePath),
   );
-  await spawn('npm', ['install'], { cwd: testModulePath });
+  await spawn(packageManager, ['install'], { cwd: testModulePath });
   resetMSVSVersion();
 }
 


### PR DESCRIPTION
The logic currently ignores a module prefix when filtering packages
passed via `--only=`. This is quite confusing: to only rebuild
something like `@theia/node-pty` we must pass `--only=node-pty`.

This commit adds a lookup using the prefixed name.