### PR TITLE
refactor: extract module walker & cache key logic to separate files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,9 +6,10 @@ import * as path from 'path';
 import ora = require('ora');
 import yargs from 'yargs/yargs';
 
-import { rebuild, ModuleType } from './rebuild';
 import { getProjectRootPath } from './search-module';
 import { locateElectronModule } from './electron-locator';
+import { ModuleType } from './module-walker';
+import { rebuild } from './rebuild';
 
 const argv = yargs(process.argv.slice(2)).version(false).options({
   version: { alias: 'v', type: 'string', description: 'The version of Electron to build against' },

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -6,18 +6,18 @@ import { cacheModuleState } from './cache';
 import { NodeGyp } from './module-type/node-gyp';
 import { Prebuildify } from './module-type/prebuildify';
 import { PrebuildInstall } from './module-type/prebuild-install';
-import { Rebuilder } from './rebuild';
+import { IRebuilder } from './types';
 
 const d = debug('electron-rebuild');
 
 export class ModuleRebuilder {
   private modulePath: string;
   private nodeGyp: NodeGyp;
-  private rebuilder: Rebuilder;
+  private rebuilder: IRebuilder;
   private prebuildify: Prebuildify;
   private prebuildInstall: PrebuildInstall;
 
-  constructor(rebuilder: Rebuilder, modulePath: string) {
+  constructor(rebuilder: IRebuilder, modulePath: string) {
     this.modulePath = modulePath;
     this.rebuilder = rebuilder;
 

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -89,12 +89,13 @@ export class ModuleRebuilder {
     return false;
   }
 
-  async rebuildNodeGypModule(cacheKey: string): Promise<void> {
+  async rebuildNodeGypModule(cacheKey: string): Promise<boolean> {
     await this.nodeGyp.rebuildModule();
     d('built via node-gyp:', this.nodeGyp.moduleName);
     await this.writeMetadata();
     await this.replaceExistingNativeModule();
     await this.cacheModuleState(cacheKey);
+    return true;
   }
 
   async replaceExistingNativeModule(): Promise<void> {
@@ -120,5 +121,11 @@ export class ModuleRebuilder {
 
   async writeMetadata(): Promise<void> {
     await fs.outputFile(this.metaPath, this.metaData);
+  }
+
+  async rebuild(cacheKey: string): Promise<boolean> {
+    return (await this.findPrebuildifyModule(cacheKey)) ||
+      (await this.findPrebuildInstallModule(cacheKey)) ||
+      (await this.rebuildNodeGypModule(cacheKey));
   }
 }

--- a/src/module-type/index.ts
+++ b/src/module-type/index.ts
@@ -3,18 +3,18 @@ import path from 'path';
 
 import { NodeAPI } from '../node-api';
 import { readPackageJson } from '../read-package-json';
-import { Rebuilder } from '../rebuild';
+import { IRebuilder } from '../types';
 
 type PackageJSONValue = string | Record<string, unknown>;
 
 export class NativeModule {
-  protected rebuilder: Rebuilder;
+  protected rebuilder: IRebuilder;
   private _moduleName: string | undefined;
   protected modulePath: string
   public nodeAPI: NodeAPI;
   private packageJSON: Record<string, PackageJSONValue | undefined>;
 
-  constructor(rebuilder: Rebuilder, modulePath: string) {
+  constructor(rebuilder: IRebuilder, modulePath: string) {
     this.rebuilder = rebuilder;
     this.modulePath = modulePath;
     this.nodeAPI = new NodeAPI(this.moduleName, this.rebuilder.electronVersion);

--- a/src/module-walker.ts
+++ b/src/module-walker.ts
@@ -1,0 +1,149 @@
+import debug from 'debug';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { readPackageJson } from './read-package-json';
+import { searchForModule, searchForNodeModules } from './search-module';
+
+const d = debug('electron-rebuild');
+
+export type ModuleType = 'prod' | 'dev' | 'optional';
+
+export class ModuleWalker {
+  buildPath: string;
+  modulesToRebuild: string[];
+  onlyModules: string[] | null;
+  prodDeps: Set<string>;
+  projectRootPath?: string;
+  realModulePaths: Set<string>;
+  realNodeModulesPaths: Set<string>;
+  types: ModuleType[];
+
+  constructor(buildPath: string, projectRootPath: string | undefined, types: ModuleType[], prodDeps: Set<string>, onlyModules: string[] | null) {
+    this.buildPath = buildPath;
+    this.modulesToRebuild = [];
+    this.projectRootPath = projectRootPath;
+    this.types = types;
+    this.prodDeps = prodDeps;
+    this.onlyModules = onlyModules;
+    this.realModulePaths = new Set();
+    this.realNodeModulesPaths = new Set();
+  }
+
+  get nodeModulesPaths(): Promise<string[]> {
+    return searchForNodeModules(
+      this.buildPath,
+      this.projectRootPath
+    );
+  }
+
+  async walkModules(): Promise<void> {
+    const rootPackageJson = await readPackageJson(this.buildPath);
+    const markWaiters: Promise<void>[] = [];
+    const depKeys = [];
+
+    if (this.types.includes('prod') || this.onlyModules) {
+      depKeys.push(...Object.keys(rootPackageJson.dependencies || {}));
+    }
+    if (this.types.includes('optional') || this.onlyModules) {
+      depKeys.push(...Object.keys(rootPackageJson.optionalDependencies || {}));
+    }
+    if (this.types.includes('dev') || this.onlyModules) {
+      depKeys.push(...Object.keys(rootPackageJson.devDependencies || {}));
+    }
+
+    for (const key of depKeys) {
+      this.prodDeps[key] = true;
+      const modulePaths: string[] = await searchForModule(
+        this.buildPath,
+        key,
+        this.projectRootPath
+      );
+      for (const modulePath of modulePaths) {
+        markWaiters.push(this.markChildrenAsProdDeps(modulePath));
+      }
+    }
+
+    await Promise.all(markWaiters);
+
+    d('identified prod deps:', this.prodDeps);
+  }
+
+  async findModule(moduleName: string, fromDir: string, foundFn: ((p: string) => Promise<void>)): Promise<void[]> {
+
+    const testPaths = await searchForModule(
+      fromDir,
+      moduleName,
+      this.projectRootPath
+    );
+    const foundFns = testPaths.map(testPath => foundFn(testPath));
+
+    return Promise.all(foundFns);
+  }
+
+  async markChildrenAsProdDeps(modulePath: string): Promise<void> {
+    if (!await fs.pathExists(modulePath)) {
+      return;
+    }
+
+    d('exploring', modulePath);
+    let childPackageJson;
+    try {
+      childPackageJson = await readPackageJson(modulePath, true);
+    } catch (err) {
+      return;
+    }
+    const moduleWait: Promise<void[]>[] = [];
+
+    const callback = this.markChildrenAsProdDeps.bind(this);
+    for (const key of Object.keys(childPackageJson.dependencies || {}).concat(Object.keys(childPackageJson.optionalDependencies || {}))) {
+      if (this.prodDeps[key]) {
+        continue;
+      }
+
+      this.prodDeps[key] = true;
+
+      moduleWait.push(this.findModule(key, modulePath, callback));
+    }
+
+    await Promise.all(moduleWait);
+  }
+
+  async findAllModulesIn(nodeModulesPath: string, prefix = ''): Promise<void> {
+    // Some package managers use symbolic links when installing node modules
+    // we need to be sure we've never tested the a package before by resolving
+    // all symlinks in the path and testing against a set
+    const realNodeModulesPath = await fs.realpath(nodeModulesPath);
+    if (this.realNodeModulesPaths.has(realNodeModulesPath)) {
+      return;
+    }
+    this.realNodeModulesPaths.add(realNodeModulesPath);
+
+    d('scanning:', realNodeModulesPath);
+
+    for (const modulePath of await fs.readdir(realNodeModulesPath)) {
+      // Ignore the magical .bin directory
+      if (modulePath === '.bin') continue;
+      // Ensure that we don't mark modules as needing to be rebuilt more than once
+      // by ignoring / resolving symlinks
+      const realPath = await fs.realpath(path.resolve(nodeModulesPath, modulePath));
+
+      if (this.realModulePaths.has(realPath)) {
+        continue;
+      }
+      this.realModulePaths.add(realPath);
+
+      if (this.prodDeps[`${prefix}${modulePath}`] && (!this.onlyModules || this.onlyModules.includes(modulePath))) {
+        this.modulesToRebuild.push(realPath);
+      }
+
+      if (modulePath.startsWith('@')) {
+        await this.findAllModulesIn(realPath, `${modulePath}/`);
+      }
+
+      if (await fs.pathExists(path.resolve(nodeModulesPath, modulePath, 'node_modules'))) {
+        await this.findAllModulesIn(path.resolve(realPath, 'node_modules'));
+      }
+    }
+  }
+}

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -70,7 +70,6 @@ export class Rebuilder {
   public useCache: boolean;
   public cachePath: string;
   public prebuildTagPrefix: string;
-  public projectRootPath?: string;
   public msvsVersion?: string;
   public useElectronClang: boolean;
   public disablePreGypCopy: boolean;
@@ -98,7 +97,6 @@ export class Rebuilder {
       console.warn('[WARNING]: Electron Rebuild has force enabled and cache enabled, force take precedence and the cache will not be used.');
       this.useCache = false;
     }
-    this.projectRootPath = options.projectRootPath;
 
     if (typeof this.electronVersion === 'number') {
       if (`${this.electronVersion}`.split('.').length === 1) {
@@ -114,7 +112,7 @@ export class Rebuilder {
     this.ABIVersion = options.forceABI?.toString();
     this.moduleWalker = new ModuleWalker(
       this.buildPath,
-      this.projectRootPath,
+      options.projectRootPath,
       this.types,
       this.extraModules.reduce((acc: Set<string>, x: string) => acc.add(x), new Set<string>()),
       this.onlyModules,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -257,17 +257,9 @@ export class Rebuilder {
       }
     }
 
-    if (await moduleRebuilder.findPrebuildifyModule(cacheKey)) {
+    if (await moduleRebuilder.rebuild(cacheKey)) {
       this.lifecycle.emit('module-done');
-      return;
     }
-
-    if (await moduleRebuilder.findPrebuildInstallModule(cacheKey)) {
-      this.lifecycle.emit('module-done');
-      return;
-    }
-    await moduleRebuilder.rebuildNodeGypModule(cacheKey);
-    this.lifecycle.emit('module-done');
   }
 }
 

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -61,7 +61,6 @@ export class Rebuilder {
   public platform: string = process.platform;
   public arch: string;
   public extraModules: string[];
-  public onlyModules: string[] | null;
   public force: boolean;
   public headerURL: string;
   public types: ModuleType[];
@@ -80,7 +79,6 @@ export class Rebuilder {
     this.electronVersion = options.electronVersion;
     this.arch = options.arch || process.arch;
     this.extraModules = options.extraModules || [];
-    this.onlyModules = options.onlyModules || null;
     this.force = options.force || false;
     this.headerURL = options.headerURL || 'https://www.electronjs.org/headers';
     this.types = options.types || defaultTypes;
@@ -115,7 +113,7 @@ export class Rebuilder {
       options.projectRootPath,
       this.types,
       this.extraModules.reduce((acc: Set<string>, x: string) => acc.add(x), new Set<string>()),
-      this.onlyModules,
+      options.onlyModules || null,
     );
     this.rebuilds = [];
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from 'events';
+
+export enum BuildType {
+  Debug = 'Debug',
+  Release = 'Release',
+}
+
+export type RebuildMode = 'sequential' | 'parallel';
+
+export interface IRebuilder {
+  ABI: string;
+  arch: string;
+  buildPath: string;
+  buildType: BuildType;
+  cachePath: string;
+  debug: boolean;
+  disablePreGypCopy: boolean;
+  electronVersion: string;
+  force: boolean;
+  headerURL: string;
+  lifecycle: EventEmitter;
+  mode: RebuildMode;
+  msvsVersion?: string;
+  platform: string;
+  prebuildTagPrefix: string;
+  useCache: boolean;
+  useElectronClang: boolean;
+}


### PR DESCRIPTION
This is pretty much a lift-and-shift to reduce the amount of logic in `src/rebuild.ts` that's not directly related to rebuilding multiple native modules. The module walker extraction is particularly useful for the upcoming replacement of that logic (see #356).

There's also a small refactor to avoid a circular import between `src/rebuild.ts` and `src/module-rebuilder.ts`.