### PR TITLE
fix: add std=c++17 flag for e20+

### DIFF
--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -89,6 +89,10 @@ export class NodeGyp extends NativeModule {
     let env: Record<string, string | undefined>;
     const extraNodeGypArgs: string[] = [];
 
+    if (semver.major(this.rebuilder.electronVersion) >= 20) {
+      process.env.CXXFLAGS = '-std=c++17';
+    }
+
     if (this.rebuilder.useElectronClang) {
       env = { ...process.env };
       const { env: clangEnv, args: clangArgs } = await getClangEnvironmentVars(this.rebuilder.electronVersion, this.rebuilder.arch);


### PR DESCRIPTION
Addresses e/e issue [34209](https://github.com/electron/electron/issues/34209) while 20.0.0-beta.1 is in beta.

This PR adds a compile flag for `-std=c++17` when using Electron 20 or higher.