### PR TITLE
fix: remove build/node_gyp_bins if it exists

### DIFF
--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -93,6 +93,7 @@ export class ModuleRebuilder {
     await this.nodeGyp.rebuildModule();
     d('built via node-gyp:', this.nodeGyp.moduleName);
     await this.writeMetadata();
+    await this.removeNodeGypBins();
     await this.replaceExistingNativeModule();
     await this.cacheModuleState(cacheKey);
     return true;
@@ -117,6 +118,16 @@ export class ModuleRebuilder {
         await fs.copyFile(nodePath, path.join(abiPath, `${this.nodeGyp.moduleName}.node`));
       }
     }
+  }
+
+  /**
+   * Removes symlinks created by node-gyp for external dependencies, such as Python.
+   * We do not want to include these in rebuilt packaged apps.
+   */
+  async removeNodeGypBins(): Promise<void> {
+    const nodeGypBinsLocation = path.resolve(this.modulePath, 'build', 'node_gyp_bins');
+    d('removing node_gyp_bins in ', nodeGypBinsLocation);
+    await fs.remove(nodeGypBinsLocation)
   }
 
   async writeMetadata(): Promise<void> {


### PR DESCRIPTION
Addresses #1024

In node-gyp v9.0.0, node-gyp adds a python symlink for older versions of python. This symlink is added to a `node_gyp_bins/python3` directory within the build directory, which electron-rebuild then tries to rebuild. This PR removes the `node_gyp_bins` directory once the node gyp module has finished rebuilding.