### PR TITLE
ci: expand test matrix to arm64 Windows and Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,11 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
       - name: Enable Long Paths (Windows)
-        if : ${{ matrix.os == 'windows-latest' }}
+        if : ${{ startsWith(matrix.os, 'windows-') }}
         run: |
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
       - name: Setup distutils (Windows)
-        if : ${{ matrix.os == 'windows-latest' }}
+        if : ${{ startsWith(matrix.os, 'windows-') }}
         run: pip3 install setuptools
       - name: Setup distutils (macOS)
         if : ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
These are now generally available, so expanding our test matrix to ensure we can rebuild on these platforms.