### PR TITLE
fix: scoped modules work with `onlyModules` / `--only`

### DIFF
--- a/src/module-walker.ts
+++ b/src/module-walker.ts
@@ -149,7 +149,8 @@ export class ModuleWalker {
       }
       this.realModulePaths.add(realPath);
 
-      if (this.prodDeps.has(`${prefix}${modulePath}`) && (!this.onlyModules || this.onlyModules.includes(modulePath))) {
+      const moduleName = `${prefix}${modulePath}`;
+      if (this.prodDeps.has(moduleName) && (!this.onlyModules || this.onlyModules.includes(moduleName))) {
         this.modulesToRebuild.push(realPath);
       }
 

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -171,13 +171,13 @@ describe('rebuilder', () => {
         buildPath: testModulePath,
         electronVersion: testElectronVersion,
         arch: process.arch,
-        onlyModules: ['windows-active-process', 'ref-napi'], // TODO: check to see if there's a bug with scoped modules
+        onlyModules: ['windows-active-process', 'ref-napi', '@newrelic/native-metrics'],
         force: true
       });
       let built = 0;
       rebuilder.lifecycle.on('module-done', () => built++);
       await rebuilder;
-      expect(built).to.equal(2);
+      expect(built).to.equal(3);
     });
   });
 


### PR DESCRIPTION
Fixes a bug where scoped modules fail when using `onlyModules` config / `--only` flag.

Found out after the fact that this was a TODO in the tests 😄