### PR TITLE
refactor: replace got with native fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "debug": "^4.1.1",
     "detect-libc": "^2.0.1",
-    "got": "^11.7.0",
     "graceful-fs": "^4.2.11",
     "node-abi": "^4.2.0",
     "node-api-version": "^0.2.1",

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,7 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import debug from 'debug';
-import got from 'got';
 
 const d = debug('electron-rebuild');
 
@@ -9,16 +8,17 @@ export async function fetch<T extends 'buffer' | 'text', RT = T extends 'buffer'
   if (retries === 0) throw new Error('Failed to fetch a clang resource, run with DEBUG=electron-rebuild for more information');
   d('downloading:', url);
   try {
-    const response = await got.default.get(url, {
-      responseType,
-    });
-    if (response.statusCode !== 200) {
-      d('got bad status code:', response.statusCode);
+    const response = await globalThis.fetch(url);
+    if (response.status !== 200) {
+      d('got bad status code:', response.status);
       await sleep(2000);
       return fetch(url, responseType, retries - 1);
     }
     d('response came back OK');
-    return response.body as RT;
+    if (responseType === 'buffer') {
+      return Buffer.from(await response.arrayBuffer()) as RT;
+    }
+    return await response.text() as RT;
   } catch (err) {
     d('request failed for some reason', err);
     await sleep(2000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,7 +416,6 @@ __metadata:
     electron: "npm:^35.7.5"
     eslint: "npm:^7.7.0"
     eslint-plugin-mocha: "npm:^9.0.0"
-    got: "npm:^11.7.0"
     graceful-fs: "npm:^4.2.11"
     mocha: "npm:^11.1.0"
     node-abi: "npm:^4.2.0"
@@ -2638,7 +2637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^11.7.0, got@npm:^11.8.5":
+"got@npm:^11.8.5":
   version: 11.8.5
   resolution: "got@npm:11.8.5"
   dependencies:


### PR DESCRIPTION
## Summary
Replaced the `got` HTTP client library with the native `fetch` API available in Node.js, removing an external dependency while maintaining the same functionality.

## Key Changes
- Removed `got` import and replaced HTTP requests with `globalThis.fetch()`
- Updated response handling to use the Fetch API's response object:
  - Changed `response.statusCode` to `response.status`
  - Changed `response.body` to conditional handling: `response.arrayBuffer()` for buffer type and `response.text()` for text type
- Removed `got` from package.json dependencies

## Implementation Details
- The fetch API is now natively available in Node.js (v18+), eliminating the need for the external `got` library
- Response type handling is now explicit with conditional logic to convert between `arrayBuffer()` and `text()` based on the requested `responseType` parameter
- The retry logic and error handling remain unchanged

https://claude.ai/code/session_01GSjWK4VdKX3bqqvED6HyXJ